### PR TITLE
Upgrade data model schema

### DIFF
--- a/src/dataModel/__init__.py
+++ b/src/dataModel/__init__.py
@@ -1,1 +1,28 @@
-# Data model package
+"""Public exports for the data models."""
+
+from .model import AccessorType, Model
+from .model_response import (
+    ModelResponse,
+    ModelResponseType,
+    DecomposedResponse,
+    ImplementedResponse,
+    FollowUpResponse,
+    FailedResponse,
+)
+from .task import Phase, Task
+from .validation_result import ValidationResult
+
+__all__ = [
+    "AccessorType",
+    "Model",
+    "ModelResponse",
+    "ModelResponseType",
+    "DecomposedResponse",
+    "ImplementedResponse",
+    "FollowUpResponse",
+    "FailedResponse",
+    "Phase",
+    "Task",
+    "ValidationResult",
+]
+

--- a/src/dataModel/model_response.py
+++ b/src/dataModel/model_response.py
@@ -1,32 +1,57 @@
 from enum import Enum
-from typing import Literal, Annotated, Union
+from typing import Annotated, Literal, Optional, Union
+
 from pydantic import BaseModel, Field
+
 from .task import Task
+
 
 class ModelResponseType(str, Enum):
     DECOMPOSED = "decomposed"
     IMPLEMENTED = "implemented"
     FOLLOW_UP_REQUIRED = "follow_up_required"
-    FAILED      = "failed"
+    FAILED = "failed"
 
-class DecomposedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.DECOMPOSED] = Field(default=ModelResponseType.DECOMPOSED)
+
+class _BaseResponse(BaseModel):
+    """Shared fields for all model responses."""
+
+    content: Optional[str] = None
+    artifacts: list[str] = Field(default_factory=list)
+
+
+class DecomposedResponse(_BaseResponse):
+    response_type: Literal[ModelResponseType.DECOMPOSED] = Field(
+        default=ModelResponseType.DECOMPOSED
+    )
     subtasks: list[Task]
 
-class FollowUpResponse(BaseModel):
-    response_type: Literal[ModelResponseType.FOLLOW_UP_REQUIRED] = Field(default=ModelResponseType.FOLLOW_UP_REQUIRED)
-    follow_up_ask: Task
 
-class ImplementedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.IMPLEMENTED] = Field(default=ModelResponseType.IMPLEMENTED)
+class ImplementedResponse(_BaseResponse):
+    response_type: Literal[ModelResponseType.IMPLEMENTED] = Field(
+        default=ModelResponseType.IMPLEMENTED
+    )
     summary: str
 
-class FailedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.FAILED] = Field(default=ModelResponseType.FAILED)
+
+class FollowUpResponse(_BaseResponse):
+    response_type: Literal[ModelResponseType.FOLLOW_UP_REQUIRED] = Field(
+        default=ModelResponseType.FOLLOW_UP_REQUIRED
+    )
+    follow_up_ask: Task
+
+
+class FailedResponse(_BaseResponse):
+    response_type: Literal[ModelResponseType.FAILED] = Field(
+        default=ModelResponseType.FAILED
+    )
     error_message: str
-    retryable: bool
+    retryable: bool = False
+
 
 ModelResponse = Annotated[
-    Union[DecomposedResponse, FollowUpResponse, ImplementedResponse, FailedResponse],
-    Field(discriminator="response_type")
+    Union[DecomposedResponse, ImplementedResponse, FollowUpResponse, FailedResponse],
+    Field(discriminator="response_type"),
 ]
+
+

--- a/src/dataModel/task.py
+++ b/src/dataModel/task.py
@@ -1,45 +1,35 @@
 from enum import Enum
-from pydantic import BaseModel
-from typing import Optional, Dict, Any
-from .model import Model
+from typing import Optional
 
-class TaskType(str, Enum):
-    IMPLEMENT_CODE   = "implement_code"
-    DESIGN_SYSTEM    = "design_system"
-    DESIGN_CODE      = "design_code"
-    DECOMPOSE        = "decompose"
-    RESEARCH_WEB     = "research_web"
-    RESEARCH_CODE    = "research_code"
-    VALIDATE_CODE    = "validate_code"
-    VALIDATE_DESIGN  = "validate_design"
-    DOCUMENT         = "document"
-    UNKNOWN          = "unknown"
+from pydantic import BaseModel, Field, model_validator
 
-class TaskStatus(str, Enum):
-    PENDING             = "pending"
-    IN_PROGRESS         = "in_progress"
-    PENDING_VALIDATION  = "pending_validation"
-    PENDING_USER_REVIEW = "pending_user_review"
-    PENDING_USER_INPUT  = "pending_user_input"
-    COMPLETED           = "completed"
-    BLOCKED             = "blocked"
-    FAILED              = "failed"
+
+class Phase(str, Enum):
+    """Project phases."""
+
+    REQUIREMENTS = "requirements"
+    RESEARCH = "research"
+    HLD = "hld"
+    LLD = "lld"
+    IMPLEMENT = "implement"
+    REVIEW = "review"
+    TEST = "test"
+    DEPLOY = "deploy"
+
 
 class Task(BaseModel):
-    task_id:   str
-    task_type: TaskType
-    prompt:    str
-    status:    TaskStatus = TaskStatus.PENDING
-    model:     Model = Model()
-    tools:     Optional[Dict[str, Any]] = None  # Available MCP tools for this task
-    result:    Optional[str] = None  # Result of the task execution
+    """A unit of work executed by the agent tree."""
 
-    class Config:
-        use_enum_values = True
+    id: str
+    description: str
+    phase: Phase
+    complexity: int = 1
+    parent_id: Optional[str] = None
+    metadata: dict = Field(default_factory=dict)
 
-# TODO: Map MCP tools to TaskTypes -- How can I do this dynamically so users can use any MCP servers
-TOOL_SET: dict[TaskType, str] = {
-
-}
-
+    @model_validator(mode="after")
+    def check_complexity(cls, data: "Task") -> "Task":
+        if data.complexity < 1:
+            raise ValueError("complexity must be >= 1")
+        return data
 


### PR DESCRIPTION
## Summary
- simplify Task model and add new Phase enum
- refactor ModelResponse to use a base class and discriminated union
- expose data model types via `src/dataModel/__init__.py`

## Testing
- `python -m pip install grimp`
- `grimp check` *(fails: command not found)*
- `python -m pydantic.version` *(fails: no output)*


------
https://chatgpt.com/codex/tasks/task_e_686616e8f61c832d93a7e18634e7e0fe