### PR TITLE
Upgrade core data models

### DIFF
--- a/src/dataModel/__init__.py
+++ b/src/dataModel/__init__.py
@@ -1,1 +1,22 @@
-# Data model package
+"""Export public data models for the TreeAgent package."""
+
+from .task import TaskType, Task, TaskStatus
+from .model_response import (
+    ModelResponse,
+    DecomposedResponse,
+    ImplementedResponse,
+    FollowUpResponse,
+    FailedResponse,
+)
+
+__all__ = [
+    "TaskType",
+    "Task",
+    "ModelResponse",
+    "DecomposedResponse",
+    "ImplementedResponse",
+    "FollowUpResponse",
+    "FailedResponse",
+    "TaskStatus",
+]
+

--- a/src/dataModel/model_response.py
+++ b/src/dataModel/model_response.py
@@ -1,32 +1,38 @@
-from enum import Enum
-from typing import Literal, Annotated, Union
+from __future__ import annotations
+
+from typing import Annotated, Literal, Optional, Union
+
 from pydantic import BaseModel, Field
+
 from .task import Task
 
-class ModelResponseType(str, Enum):
-    DECOMPOSED = "decomposed"
-    IMPLEMENTED = "implemented"
-    FOLLOW_UP_REQUIRED = "follow_up_required"
-    FAILED      = "failed"
 
-class DecomposedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.DECOMPOSED] = Field(default=ModelResponseType.DECOMPOSED)
+class _BaseResponse(BaseModel):
+    content: Optional[str] = None
+    artifacts: list[str] = []
+
+
+class DecomposedResponse(_BaseResponse):
+    response_type: Literal["decomposed"] = Field("decomposed", const=True)
     subtasks: list[Task]
 
-class FollowUpResponse(BaseModel):
-    response_type: Literal[ModelResponseType.FOLLOW_UP_REQUIRED] = Field(default=ModelResponseType.FOLLOW_UP_REQUIRED)
+
+class ImplementedResponse(_BaseResponse):
+    response_type: Literal["implemented"] = Field("implemented", const=True)
+
+
+class FollowUpResponse(_BaseResponse):
+    response_type: Literal["follow_up_required"] = Field("follow_up_required", const=True)
     follow_up_ask: Task
 
-class ImplementedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.IMPLEMENTED] = Field(default=ModelResponseType.IMPLEMENTED)
-    summary: str
 
-class FailedResponse(BaseModel):
-    response_type: Literal[ModelResponseType.FAILED] = Field(default=ModelResponseType.FAILED)
+class FailedResponse(_BaseResponse):
+    response_type: Literal["failed"] = Field("failed", const=True)
     error_message: str
-    retryable: bool
+    retryable: bool = False
+
 
 ModelResponse = Annotated[
-    Union[DecomposedResponse, FollowUpResponse, ImplementedResponse, FailedResponse],
-    Field(discriminator="response_type")
+    Union[DecomposedResponse, ImplementedResponse, FollowUpResponse, FailedResponse],
+    Field(discriminator="response_type"),
 ]


### PR DESCRIPTION
## Summary
- add Phase enum and new Task model
- update ModelResponse base/variants and union
- export public data models
- rename `phase` field to `type` and reintroduce `TaskStatus`
- rename Phase enum to TaskType

## Testing
- `python -m pydantic.version`
- `grimp check src` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686616e8f61c832d93a7e18634e7e0fe