### PR TITLE
Add Pydantic model tests

### DIFF
--- a/src/dataModel/model_response.py
+++ b/src/dataModel/model_response.py
@@ -13,21 +13,21 @@ class _BaseResponse(BaseModel):
 
 
 class DecomposedResponse(_BaseResponse):
-    response_type: Literal["decomposed"] = Field("decomposed", const=True)
+    response_type: Literal["decomposed"] = Field("decomposed")
     subtasks: list[Task]
 
 
 class ImplementedResponse(_BaseResponse):
-    response_type: Literal["implemented"] = Field("implemented", const=True)
+    response_type: Literal["implemented"] = Field("implemented")
 
 
 class FollowUpResponse(_BaseResponse):
-    response_type: Literal["follow_up_required"] = Field("follow_up_required", const=True)
+    response_type: Literal["follow_up_required"] = Field("follow_up_required")
     follow_up_ask: Task
 
 
 class FailedResponse(_BaseResponse):
-    response_type: Literal["failed"] = Field("failed", const=True)
+    response_type: Literal["failed"] = Field("failed")
     error_message: str
     retryable: bool = False
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import pytest
+from pydantic import ValidationError
+
+from dataModel import (
+    Task,
+    TaskType,
+    DecomposedResponse,
+    ImplementedResponse,
+    FollowUpResponse,
+    FailedResponse,
+)
+
+
+def build_task(task_id: str = "t1") -> Task:
+    return Task(id=task_id, description="desc", type=TaskType.HLD)
+
+
+def test_task_type_enum_invariance():
+    assert TaskType("hld") is TaskType.HLD
+
+
+def test_task_complexity_validation():
+    with pytest.raises(ValidationError):
+        Task(id="bad", description="d", type=TaskType.HLD, complexity=0)
+
+
+@pytest.mark.parametrize(
+    "cls, kwargs, tag",
+    [
+        (DecomposedResponse, {"subtasks": [build_task("sub")]}, "decomposed"),
+        (ImplementedResponse, {}, "implemented"),
+        (
+            FollowUpResponse,
+            {"follow_up_ask": build_task("follow")},
+            "follow_up_required",
+        ),
+        (FailedResponse, {"error_message": "oops"}, "failed"),
+    ],
+)
+def test_model_response_round_trip_and_discriminator(cls, kwargs, tag):
+    orig = cls(**kwargs)
+    packed = orig.model_dump()
+    restored = cls.model_validate(packed)
+    assert restored == orig
+    assert packed["response_type"] == tag


### PR DESCRIPTION
## Summary
- add basic unit tests for Task and ModelResponse models
- remove deprecated `const=True` usage for Pydantic v2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bfa5aa04832da3cefb78ce274940