### PR TITLE
Add stub agent nodes with tests

### DIFF
--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict
+
+from pydantic import TypeAdapter
+from dataModel.task import Task, TaskType
+from dataModel.model_response import (
+    FollowUpResponse,
+    ImplementedResponse,
+    DecomposedResponse,
+    ModelResponse,
+)
+
+from litellm import with_structured_output
+
+
+class Clarifier:
+    """Decides whether the root task needs clarifying questions."""
+
+    SCHEMA = TypeAdapter(FollowUpResponse | ImplementedResponse)
+    SCHEMA.model_validate = SCHEMA.validate_python  # for convenience
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        root_task: Task = state["root_task"]
+        if root_task.description.strip().endswith("?"):
+            resp = FollowUpResponse(
+                follow_up_ask=Task(
+                    id=f"{root_task.id}-followup",
+                    description="Need more details",
+                    type=TaskType.REQUIREMENTS,
+                    complexity=1,
+                )
+            )
+        else:
+            resp = ImplementedResponse(content="Requirements already clear")
+
+        _ = with_structured_output(self.SCHEMA)
+        return resp.model_dump()

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict
+
+from pydantic import TypeAdapter
+from dataModel.task import Task, TaskType
+from dataModel.model_response import (
+    FollowUpResponse,
+    ImplementedResponse,
+    DecomposedResponse,
+    ModelResponse,
+)
+
+from litellm import with_structured_output
+
+
+class HLDDesigner:
+    """Creates high-level design subtasks or a simple outline."""
+
+    SCHEMA = TypeAdapter(DecomposedResponse | ImplementedResponse)
+    SCHEMA.model_validate = SCHEMA.validate_python
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        task_queue = state["task_queue"]
+        current_task: Task = task_queue[0]
+        if current_task.complexity > 1:
+            subtasks = [
+                Task(
+                    id=f"{current_task.id}-{i+1}",
+                    description=f"HLD step {i+1}",
+                    type=TaskType.HLD,
+                    complexity=1,
+                    parent_id=current_task.id,
+                )
+                for i in range(current_task.complexity)
+            ]
+            resp = DecomposedResponse(subtasks=subtasks)
+        else:
+            resp = ImplementedResponse(content="HLD outline ...")
+
+        _ = with_structured_output(self.SCHEMA)
+        return resp.model_dump()

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict
+
+from pydantic import TypeAdapter
+from dataModel.task import Task, TaskType
+from dataModel.model_response import (
+    FollowUpResponse,
+    ImplementedResponse,
+    DecomposedResponse,
+    ModelResponse,
+)
+
+from litellm import with_structured_output
+
+
+class Researcher:
+    """Gathers research artifacts for a task."""
+
+    SCHEMA = TypeAdapter(ImplementedResponse)
+    SCHEMA.model_validate = SCHEMA.validate_python
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        resp = ImplementedResponse(artifacts=["https://example.com"])
+        _ = with_structured_output(self.SCHEMA)
+        return resp.model_dump()

--- a/src/litellm/__init__.py
+++ b/src/litellm/__init__.py
@@ -1,0 +1,19 @@
+"""Minimal stub of the litellm API used for tests."""
+
+from typing import Any, Callable
+
+
+def with_structured_output(schema: Any) -> Callable[[Any], Any]:
+    """Return a decorator that validates structured output.
+
+    This is a lightweight placeholder and simply returns a function that
+    returns the provided value without calling any model.
+    """
+
+    def decorator(fn: Callable[[Any], Any]) -> Callable[[Any], Any]:
+        def wrapper(value: Any) -> Any:
+            return value
+
+        return wrapper
+
+    return decorator

--- a/tests/nodes/test_clarifier.py
+++ b/tests/nodes/test_clarifier.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from agentNodes.clarifier import Clarifier
+from dataModel.task import Task, TaskType
+from dataModel.model_response import FollowUpResponse, ImplementedResponse
+
+import litellm
+
+litellm.with_structured_output = lambda *a, **k: (lambda x: x)
+
+
+def test_clarifier_followup():
+    node = Clarifier()
+    state = {"root_task": Task(id="t1", description="Need specs?", type=TaskType.REQUIREMENTS)}
+    res = node(state, {})
+    parsed = Clarifier.SCHEMA.model_validate(res)
+    assert isinstance(parsed, FollowUpResponse)
+
+
+def test_clarifier_implemented():
+    node = Clarifier()
+    state = {"root_task": Task(id="t1", description="All clear", type=TaskType.REQUIREMENTS)}
+    res = node(state, {})
+    parsed = Clarifier.SCHEMA.model_validate(res)
+    assert isinstance(parsed, ImplementedResponse)

--- a/tests/nodes/test_hld_designer.py
+++ b/tests/nodes/test_hld_designer.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from agentNodes.hld_designer import HLDDesigner
+from dataModel.task import Task, TaskType
+from dataModel.model_response import DecomposedResponse, ImplementedResponse
+
+import litellm
+
+litellm.with_structured_output = lambda *a, **k: (lambda x: x)
+
+
+def test_hld_designer_decomposes():
+    node = HLDDesigner()
+    task = Task(id="h1", description="HLD", type=TaskType.HLD, complexity=3)
+    state = {"task_queue": [task]}
+    res = node(state, {})
+    parsed = HLDDesigner.SCHEMA.model_validate(res)
+    assert isinstance(parsed, DecomposedResponse)
+    assert len(parsed.subtasks) == 3
+    assert all(st.type == TaskType.HLD for st in parsed.subtasks)
+
+
+def test_hld_designer_implemented():
+    node = HLDDesigner()
+    task = Task(id="h1", description="HLD", type=TaskType.HLD, complexity=1)
+    state = {"task_queue": [task]}
+    res = node(state, {})
+    parsed = HLDDesigner.SCHEMA.model_validate(res)
+    assert isinstance(parsed, ImplementedResponse)

--- a/tests/nodes/test_researcher.py
+++ b/tests/nodes/test_researcher.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from agentNodes.researcher import Researcher
+from dataModel.model_response import ImplementedResponse
+
+import litellm
+
+litellm.with_structured_output = lambda *a, **k: (lambda x: x)
+
+
+def test_researcher_returns_artifact():
+    node = Researcher()
+    state = {}
+    res = node(state, {})
+    parsed = Researcher.SCHEMA.model_validate(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.artifacts == ["https://example.com"]

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import litellm
+
+litellm.with_structured_output = lambda *a, **k: (lambda x: x)
+
+from agentNodes.clarifier import Clarifier
+from agentNodes.researcher import Researcher
+from agentNodes.hld_designer import HLDDesigner
+from pydantic import TypeAdapter
+from dataModel.task import Task, TaskType
+from dataModel.model_response import ModelResponse, DecomposedResponse
+
+NODE_REGISTRY = {
+    "clarify": Clarifier(),
+    "research": Researcher(),
+    "hld": HLDDesigner(),
+}
+
+def route(task: Task, state: dict) -> dict:
+    if "?" in task.description:
+        return NODE_REGISTRY["clarify"](state, {})
+    if task.type == TaskType.RESEARCH:
+        return NODE_REGISTRY["research"](state, {})
+    return NODE_REGISTRY["hld"](state, {})
+
+
+def test_end_to_end_chain():
+    root = Task(id="root", description="Build a web app?", type=TaskType.REQUIREMENTS)
+    state = {"root_task": root, "task_queue": [root]}
+
+    # Clarifier step
+    clarifier_res = route(root, state)
+    adapter = TypeAdapter(ModelResponse)
+    clarifier_parsed = adapter.validate_python(clarifier_res)
+    assert clarifier_parsed.response_type == "follow_up_required"
+
+    # user provides details -> research task
+    research_task = Task(id="r1", description="Gather stack", type=TaskType.RESEARCH)
+    state["task_queue"] = [research_task]
+    research_res = route(research_task, state)
+    research_parsed = adapter.validate_python(research_res)
+    assert research_parsed.response_type == "implemented"
+
+    # design phase
+    design_task = Task(id="d1", description="Design", type=TaskType.HLD, complexity=2)
+    state["task_queue"] = [design_task]
+    design_res = route(design_task, state)
+    design_parsed = adapter.validate_python(design_res)
+    assert isinstance(design_parsed, DecomposedResponse)
+    assert len(design_parsed.subtasks) == 2


### PR DESCRIPTION
## Summary
- add Clarifier, Researcher and HLDDesigner node stubs
- include minimal `litellm.with_structured_output` stub
- implement unit tests for each node and an e2e test exercising node routing

## Testing
- `pytest -q`
- `pytest --strict-markers -q`


------
https://chatgpt.com/codex/tasks/task_e_6866dae92b64832d8d292acda62840b2