### PR TITLE
Add pipeline nodes with tests

### DIFF
--- a/src/agentNodes/deployer.py
+++ b/src/agentNodes/deployer.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict
+
+from dataModel.model_response import ImplementedResponse
+
+
+class Deployer:
+    """Deploys the final artifact."""
+
+    SCHEMA = ImplementedResponse
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        last = state["last_response"]
+        resp = ImplementedResponse(content="deployed", artifacts=last.artifacts)
+        return resp.model_dump()

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict
+
+from dataModel.model_response import ImplementedResponse
+
+
+class Implementer:
+    """Generates code artifacts."""
+
+    SCHEMA = ImplementedResponse
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        resp = ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
+        return resp.model_dump()

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict
+
+from dataModel.model_response import ImplementedResponse
+
+
+class LLDDesigner:
+    """Produces low-level design documentation."""
+
+    SCHEMA = ImplementedResponse
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        resp = ImplementedResponse(content="LLD doc ...")
+        return resp.model_dump()

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+from dataModel.model_response import ImplementedResponse, FailedResponse
+
+
+class Reviewer:
+    """Reviews implemented code and either approves or rejects."""
+
+    SCHEMA = ImplementedResponse | FailedResponse
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        last = state["last_response"]
+        content = last.content or ""
+        if "def" in content:
+            resp = ImplementedResponse(content="LGTM", artifacts=last.artifacts)
+        else:
+            resp = FailedResponse(error_message="Style error")
+        return resp.model_dump()

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict
+
+from dataModel.model_response import ImplementedResponse
+
+
+class Tester:
+    """Runs tests on the implementation."""
+
+    SCHEMA = ImplementedResponse
+
+    def __call__(self, state: Dict[str, Any], config: Dict[str, Any] | None = None) -> dict:
+        resp = ImplementedResponse(content="pytest passed")
+        return resp.model_dump()

--- a/tests/nodes/test_deployer.py
+++ b/tests/nodes/test_deployer.py
@@ -1,0 +1,14 @@
+from pydantic import TypeAdapter
+
+from agentNodes.deployer import Deployer
+from dataModel.model_response import ImplementedResponse
+
+
+def test_deployer_deploys():
+    node = Deployer()
+    last = ImplementedResponse(content="pytest passed", artifacts=["foo.py"])
+    res = node({"last_response": last}, {})
+    parsed = TypeAdapter(Deployer.SCHEMA).validate_python(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.content == "deployed"
+    assert parsed.artifacts == ["foo.py"]

--- a/tests/nodes/test_implementer.py
+++ b/tests/nodes/test_implementer.py
@@ -1,0 +1,12 @@
+from pydantic import TypeAdapter
+
+from agentNodes.implementer import Implementer
+from dataModel.model_response import ImplementedResponse
+
+
+def test_implementer_returns_code():
+    node = Implementer()
+    res = node({}, {})
+    parsed = TypeAdapter(Implementer.SCHEMA).validate_python(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.artifacts == ["foo.py"]

--- a/tests/nodes/test_lld_designer.py
+++ b/tests/nodes/test_lld_designer.py
@@ -1,0 +1,12 @@
+from pydantic import TypeAdapter
+
+from agentNodes.lld_designer import LLDDesigner
+from dataModel.model_response import ImplementedResponse
+
+
+def test_lld_designer_returns_doc():
+    node = LLDDesigner()
+    res = node({}, {})
+    parsed = TypeAdapter(LLDDesigner.SCHEMA).validate_python(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.content.startswith("LLD")

--- a/tests/nodes/test_reviewer.py
+++ b/tests/nodes/test_reviewer.py
@@ -1,0 +1,23 @@
+from pydantic import TypeAdapter
+
+from agentNodes.reviewer import Reviewer
+from dataModel.model_response import ImplementedResponse, FailedResponse
+
+
+def test_reviewer_approves():
+    node = Reviewer()
+    last = ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
+    res = node({"last_response": last}, {})
+    parsed = TypeAdapter(Reviewer.SCHEMA).validate_python(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.content == "LGTM"
+    assert parsed.artifacts == ["foo.py"]
+
+
+def test_reviewer_rejects():
+    node = Reviewer()
+    last = ImplementedResponse(content="print(1)", artifacts=["foo.py"])
+    res = node({"last_response": last}, {})
+    parsed = TypeAdapter(Reviewer.SCHEMA).validate_python(res)
+    assert isinstance(parsed, FailedResponse)
+    assert parsed.error_message == "Style error"

--- a/tests/nodes/test_tester.py
+++ b/tests/nodes/test_tester.py
@@ -1,0 +1,12 @@
+from pydantic import TypeAdapter
+
+from agentNodes.tester import Tester
+from dataModel.model_response import ImplementedResponse
+
+
+def test_tester_passed():
+    node = Tester()
+    res = node({}, {})
+    parsed = TypeAdapter(Tester.SCHEMA).validate_python(res)
+    assert isinstance(parsed, ImplementedResponse)
+    assert parsed.content == "pytest passed"


### PR DESCRIPTION
## Summary
- implement stub nodes for LLD design, implementation, review, test and deployment
- cover each new node with unit tests
- extend the end‑to‑end test with implementer→reviewer→tester→deployer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f19dd080832d80ca69ccafb7d79b