### PR TITLE
Refactor Clarifier to use LLM accessor

### DIFF
--- a/tests/agentNodes/test_clarifier.py
+++ b/tests/agentNodes/test_clarifier.py
@@ -1,20 +1,41 @@
 from pydantic import TypeAdapter
 from agentNodes.clarifier import Clarifier
+from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.task import Task, TaskType
 from dataModel.model_response import FollowUpResponse, ImplementedResponse
 
 
-def test_clarifier_followup():
-    node = Clarifier()
-    state = {"root_task": Task(id="t1", description="Need specs?", type=TaskType.REQUIREMENTS)}
-    res = node(state, {})
-    parsed = TypeAdapter(Clarifier.SCHEMA).validate_python(res)
-    assert isinstance(parsed, FollowUpResponse)
+class _StubAccessor(BaseModelAccessor):
+    def call_model(self, prompt: str, schema):
+        raise NotImplementedError()
+
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+        raise NotImplementedError()
+
+    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+        raise NotImplementedError()
 
 
-def test_clarifier_implemented():
-    node = Clarifier()
-    state = {"root_task": Task(id="t1", description="All clear", type=TaskType.REQUIREMENTS)}
-    res = node(state, {})
-    parsed = TypeAdapter(Clarifier.SCHEMA).validate_python(res)
-    assert isinstance(parsed, ImplementedResponse)
+def test_needs_followup(monkeypatch):
+    follow_up = Task(id="t1-fu", description="Need more details", type=TaskType.REQUIREMENTS)
+    accessor = _StubAccessor()
+    node = Clarifier(accessor)
+    monkeypatch.setattr(node.llm_accessor, "call_model", lambda prompt, schema: FollowUpResponse(follow_up_ask=follow_up))
+    task = Task(id="t1", description="Build app?", type=TaskType.REQUIREMENTS)
+
+    res = node.execute_task(task)
+
+    assert isinstance(res, FollowUpResponse)
+    assert res.follow_up_ask == follow_up
+
+
+def test_no_followup(monkeypatch):
+    accessor = _StubAccessor()
+    node = Clarifier(accessor)
+    monkeypatch.setattr(node.llm_accessor, "call_model", lambda prompt, schema: ImplementedResponse(content="Requirements are clear"))
+    task = Task(id="t2", description="All good", type=TaskType.REQUIREMENTS)
+
+    res = node.execute_task(task)
+
+    assert isinstance(res, ImplementedResponse)
+    assert res.content == "Requirements are clear"

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -9,7 +9,7 @@ from agentNodes.reviewer import Reviewer
 from agentNodes.tester import Tester
 from agentNodes.deployer import Deployer
 from dataModel.task import Task, TaskType
-from dataModel.model_response import ModelResponse, DecomposedResponse, ImplementedResponse
+from dataModel.model_response import ModelResponse, DecomposedResponse, ImplementedResponse, FollowUpResponse
 
 
 class _StubAccessor(BaseModelAccessor):
@@ -34,8 +34,16 @@ def _hld_call_model(prompt: str, schema):
         return DecomposedResponse(subtasks=subtasks)
     return ImplementedResponse(content="outline")
 
+
+def _clarify_call_model(prompt: str, schema):
+    if "?" in prompt:
+        return FollowUpResponse(
+            follow_up_ask=Task(id="root-fu", description="Need more info", type=TaskType.REQUIREMENTS)
+        )
+    return ImplementedResponse(content="Requirements are clear")
+
 NODE_REGISTRY = {
-    "clarify": Clarifier(),
+    "clarify": Clarifier(_StubAccessor(_clarify_call_model)),
     "research": Researcher(),
     "hld": HLDDesigner(_StubAccessor(_hld_call_model)),
     "implement": Implementer(),


### PR DESCRIPTION
## Summary
- convert Clarifier node to use a model accessor
- update Clarifier tests for new execute_task behavior
- adapt end-to-end node tests for new Clarifier signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c9c9a4b68832d886dae166fdb88d6