### PR TITLE
Add class-based env tools

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,14 @@
+from .web_search import WEB_SEARCH_TOOL, web_search
+from .env_tools import (
+    EnvManager,
+    PYTHON_REQUIREMENTS_TOOL,
+    NPM_INSTALL_TOOL,
+)
+
+__all__ = [
+    "WEB_SEARCH_TOOL",
+    "web_search",
+    "EnvManager",
+    "PYTHON_REQUIREMENTS_TOOL",
+    "NPM_INSTALL_TOOL",
+]

--- a/src/tools/env_tools.py
+++ b/src/tools/env_tools.py
@@ -1,0 +1,45 @@
+import subprocess
+
+from modelAccessors.data.tool import Tool
+
+
+class EnvManager:
+    """Run environment commands inside a specific path."""
+
+    def __init__(self, env_path: str) -> None:
+        self.env_path = env_path
+
+    def _run(self, cmd: list[str]) -> bool:
+        try:
+            subprocess.run(
+                cmd,
+                cwd=self.env_path,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    def install_python_requirements(self) -> bool:
+        """Install Python dependencies from ``requirements.txt`` using pip."""
+        return self._run(["pip", "install", "-r", "requirements.txt"])
+
+    def npm_install(self) -> bool:
+        """Install JavaScript dependencies using ``npm install``."""
+        return self._run(["npm", "install"])
+
+
+PYTHON_REQUIREMENTS_TOOL = Tool(
+    name="install_python_requirements",
+    description="Install Python dependencies from requirements.txt",
+    parameters={},
+)
+
+NPM_INSTALL_TOOL = Tool(
+    name="npm_install",
+    description="Install npm dependencies",
+    parameters={},
+)
+

--- a/tests/tools/test_env_tools.py
+++ b/tests/tools/test_env_tools.py
@@ -1,0 +1,43 @@
+import subprocess
+
+from tools.env_tools import EnvManager
+
+
+def test_npm_install_runs_command(monkeypatch):
+    calls = {}
+
+    def fake_run(cmd, cwd=None, check=True, stdout=None, stderr=None):
+        calls["cmd"] = cmd
+        calls["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    env = EnvManager("/env")
+    assert env.npm_install() is True
+    assert calls["cmd"] == ["npm", "install"]
+    assert calls["cwd"] == "/env"
+
+
+def test_install_python_requirements_handles_error(monkeypatch):
+    def fake_run(cmd, cwd=None, check=True, stdout=None, stderr=None):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    env = EnvManager("/env")
+    assert env.install_python_requirements() is False
+
+
+def test_multiple_envs_independent(monkeypatch):
+    cwds = []
+
+    def fake_run(cmd, cwd=None, check=True, stdout=None, stderr=None):
+        cwds.append(cwd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    env_a = EnvManager("/a")
+    env_b = EnvManager("/b")
+    env_a.npm_install()
+    env_b.install_python_requirements()
+    assert cwds == ["/a", "/b"]
+


### PR DESCRIPTION
## Summary
- refactor env tools to use `EnvManager` class for multiple paths
- update exports from `tools` package
- rewrite env tool tests for new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ebcd2e490832d92d89a97bf2f95a9