### PR TITLE
Add file I/O class with locking

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -4,6 +4,13 @@ from .env_tools import (
     PYTHON_REQUIREMENTS_TOOL,
     NPM_INSTALL_TOOL,
 )
+from .file_io import (
+    FileManager,
+    READ_FILE_TOOL,
+    WRITE_FILE_TOOL,
+    read_file,
+    write_file,
+)
 
 __all__ = [
     "WEB_SEARCH_TOOL",
@@ -11,4 +18,9 @@ __all__ = [
     "EnvManager",
     "PYTHON_REQUIREMENTS_TOOL",
     "NPM_INSTALL_TOOL",
+    "FileManager",
+    "READ_FILE_TOOL",
+    "WRITE_FILE_TOOL",
+    "read_file",
+    "write_file",
 ]

--- a/src/tools/file_io.py
+++ b/src/tools/file_io.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import threading
+
+from modelAccessors.data.tool import Tool
+
+
+class FileManager:
+    """Simple file reader/writer with a shared lock."""
+
+    _lock = threading.Lock()
+
+    def read_file(self, path: str, size: int | None = None) -> str:
+        """Return the file contents, optionally limited to ``size`` bytes."""
+        with FileManager._lock, open(path, "r", encoding="utf-8") as f:
+            return f.read(size) if size is not None else f.read()
+
+    def write_file(self, path: str, content: str) -> bool:
+        """Write ``content`` to ``path``. Return ``True`` on success."""
+        try:
+            with FileManager._lock, open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+            return True
+        except OSError:
+            return False
+
+
+_FILE_MANAGER = FileManager()
+
+
+def read_file(path: str, size: int | None = None) -> str:
+    return _FILE_MANAGER.read_file(path, size)
+
+
+def write_file(path: str, content: str) -> bool:
+    return _FILE_MANAGER.write_file(path, content)
+
+
+READ_FILE_TOOL = Tool(
+    name="read_file",
+    description="Read a file and return its contents (optionally limited)",
+    parameters={"path": {"type": "string"}, "size": {"type": "integer", "optional": True}},
+)
+
+WRITE_FILE_TOOL = Tool(
+    name="write_file",
+    description="Write text content to a file",
+    parameters={"path": {"type": "string"}, "content": {"type": "string"}},
+)

--- a/tests/tools/test_file_io.py
+++ b/tests/tools/test_file_io.py
@@ -1,0 +1,69 @@
+import builtins
+import io
+
+from tools.file_io import FileManager, read_file, write_file
+
+
+def test_read_file_returns_contents(monkeypatch):
+    def fake_open(path, mode="r", encoding=None):
+        assert path == "/tmp/foo.txt"
+        assert mode == "r"
+        return io.StringIO("hello")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert read_file("/tmp/foo.txt") == "hello"
+
+
+def test_read_file_respects_size_limit(monkeypatch):
+    def fake_open(path, mode="r", encoding=None):
+        return io.StringIO("hello")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert read_file("/tmp/foo.txt", size=2) == "he"
+
+
+def test_write_file_writes_data(monkeypatch):
+    written = {}
+
+    class _File(io.StringIO):
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            written["data"] = self.getvalue()
+            return False
+
+    def fake_open(path, mode="w", encoding=None):
+        assert path == "/tmp/out.txt"
+        assert mode == "w"
+        return _File()
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert write_file("/tmp/out.txt", "data") is True
+    assert written["data"] == "data"
+
+
+def test_write_file_handles_error(monkeypatch):
+    def fake_open(path, mode="w", encoding=None):
+        raise OSError
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert write_file("/bad", "x") is False
+
+
+def test_lock_is_used(monkeypatch):
+    events = []
+
+    class FakeLock:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            events.append("exit")
+
+    monkeypatch.setattr(FileManager, "_lock", FakeLock())
+
+    def fake_open(path, mode="r", encoding=None):
+        return io.StringIO("x")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    assert read_file("/tmp/x") == "x"
+    assert events == ["enter", "exit"]


### PR DESCRIPTION
## Summary
- refactor file IO helpers into `FileManager` class
- add shared locking and optional size limit
- export new class from `tools`
- update and extend file IO tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec05f92d0832d9b9cc930c9c04d51