### PR TITLE
Add CI workflow with lint and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest ruff mypy
+      - name: Run linter
+        run: ruff check .
+      - name: Run type checks
+        run: |
+          PYTHONPATH=src mypy --ignore-missing-imports src tests
+      - name: Run tests
+        run: pytest -q

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+show_error_codes = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ treeagent = "cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run ruff, mypy and pytest on pushes and PRs
- configure mypy and ruff

## Testing
- `ruff check .` *(fails: Found 7 errors)*
- `PYTHONPATH=src mypy --ignore-missing-imports src tests` *(fails with type errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870211a4464832db68a779360e874d5