### PR TITLE
Fix python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tree-agent"
 version = "0.1.0"
 description = "AI Agent Tree Orchestrator"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 dependencies = [
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
- change `requires-python` to `>=3.11`

## Testing
- `ruff check .` *(fails: F401 unused imports)*
- `PYTHONPATH=src mypy --ignore-missing-imports src tests` *(fails: found 81 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707df1bf1c832da05811ef9980f9ea