### PR TITLE
Add pytest-cov dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,23 @@ TreeAgent/
 │   ├── dataModel/          # pydantic task / response schemas
 │   └── ...
 ├── examples/               # minimal end-to-end scenarios (coming soon)
-├── tests/                  # pytest suite (empty for now)
+├── tests/                  # pytest suite
 ├── requirements.txt
 └── README.md
+```
+
+## 🧪 Running Tests
+
+Install the optional dev dependencies to enable coverage reporting:
+
+```bash
+pip install -e .[dev] pytest
+```
+
+Execute the suite with coverage enabled:
+
+```bash
+pytest --cov=src
 ```
 
 ## 🛣️ Roadmap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = []
+dev = [
+    "pytest-cov>=5.0",
+]
 
 [project.scripts]
 treeagent = "cli:main"


### PR DESCRIPTION
## Summary
- include pytest-cov in optional dev dependencies
- show how to run tests with coverage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687727841a70832d8e65241ae4f8eeff