### PR TITLE
Enforce spawn rules via config

### DIFF
--- a/config/spawn_rules.json
+++ b/config/spawn_rules.json
@@ -1,5 +1,5 @@
 {
-  "HLD": { "can_spawn": { "IMPLEMENT": 5, "RESEARCH": 5, "TEST": 1 }, "self_spawn": false },
+  "HLD": { "can_spawn": { "LLD": 5, "RESEARCH": 5, "TEST": 1 }, "self_spawn": false },
   "LLD": { "can_spawn": { "IMPLEMENT": 5, "RESEARCH": 3, "TEST": 1 }, "self_spawn": false },
   "IMPLEMENT": { "can_spawn": { "RESEARCH": 1, "TEST": 1 }, "self_spawn": false },
   "REVIEW": { "can_spawn": { "IMPLEMENT": 1 }, "self_spawn": false },

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -16,7 +16,8 @@ class HLDDesigner:
     PROMPT_TEMPLATE = (
         "Create a high level design based on the following requirements:\n"
         "{requirements}\n"
-        "Complexity: {complexity}"
+        "Complexity: {complexity}\n"
+        "Provide at most 5 subtasks using only the types: LLD, RESEARCH, TEST."
     )
 
     SCHEMA = DecomposedResponse | ImplementedResponse

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -11,7 +11,8 @@ class LLDDesigner:
     PROMPT_TEMPLATE = (
         "Create a low level design based on the following description:\n"
         "{description}\n"
-        "Complexity: {complexity}"
+        "Complexity: {complexity}\n"
+        "Return at most 5 subtasks using only the types: IMPLEMENT, RESEARCH, TEST."
     )
 
     SCHEMA = ImplementedResponse


### PR DESCRIPTION
## Summary
- move spawn rules into `config/spawn_rules.json`
- allow orchestrator to find rules in `config/`
- enforce `self_spawn` flag when filtering subtasks
- mention spawn limits in HLD/LLD prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687866b4d0e0832da7b1fbaee9d22594