### PR TITLE
Add project checkpoint persistence

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -14,7 +14,17 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "prompt",
+        nargs="?",  # optional so --resume can be used without a prompt
         help="Description of the project to implement",
+    )
+    parser.add_argument(
+        "--resume",
+        help="Path to a checkpoint directory to resume",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        default="checkpoints",
+        help="Directory to store project checkpoints",
     )
     return parser.parse_args()
 
@@ -24,7 +34,12 @@ def main() -> None:
     args = parse_args()
 
     orchestrator = AgentOrchestrator()
-    project = orchestrator.implement_project(args.prompt)
+    if args.resume:
+        project = orchestrator.resume_project(args.resume)
+    elif args.prompt:
+        project = orchestrator.implement_project(args.prompt, checkpoint_dir=args.checkpoint_dir)
+    else:
+        raise SystemExit("Provide a prompt or --resume path")
 
     print("Project Summary:")
     print(f"Completed Tasks: {len(project.completedTasks)}")

--- a/src/dataManagement/__init__.py
+++ b/src/dataManagement/__init__.py
@@ -1,0 +1,13 @@
+"""Project persistence helpers."""
+
+from .project_manager import (
+    save_project_state,
+    load_project_state,
+    latest_snapshot_path,
+)
+
+__all__ = [
+    "save_project_state",
+    "load_project_state",
+    "latest_snapshot_path",
+]

--- a/src/dataManagement/project_manager.py
+++ b/src/dataManagement/project_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from dataModel.project import Project
+
+
+def save_project_state(project: Project, directory: str | Path) -> Path:
+    """Save ``project`` to ``directory`` with a timestamped filename."""
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    file_path = dir_path / f"{timestamp}.json"
+    tmp = file_path.with_suffix(file_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(project.model_dump(), indent=2))
+    tmp.replace(file_path)
+    return file_path
+
+
+def load_project_state(file_path: str | Path) -> Project:
+    """Load a :class:`Project` from ``file_path``."""
+    data = json.loads(Path(file_path).read_text())
+    project = Project.model_validate(data)
+    if project.inProgressTasks:
+        # tasks might have been mid-flight when the snapshot was taken; restart them
+        project.queuedTasks = project.inProgressTasks + project.queuedTasks
+        project.inProgressTasks = []
+    return project
+
+
+def latest_snapshot_path(directory: str | Path) -> Path:
+    """Return the most recent snapshot file in ``directory``."""
+    dir_path = Path(directory)
+    snapshots = sorted(dir_path.glob("*.json"))
+    if not snapshots:
+        raise FileNotFoundError(f"no snapshot in {directory}")
+    return snapshots[-1]

--- a/src/dataModel/__init__.py
+++ b/src/dataModel/__init__.py
@@ -1,6 +1,7 @@
 """Export public data models for the TreeAgent package."""
 
 from .task import TaskType, Task, TaskStatus
+from .project import Project
 from .model_response import (
     ModelResponse,
     ModelResponseType,
@@ -20,5 +21,6 @@ __all__ = [
     "FollowUpResponse",
     "FailedResponse",
     "TaskStatus",
+    "Project",
 ]
 

--- a/src/dataModel/project.py
+++ b/src/dataModel/project.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from .task import Task
+
+
+class Project(BaseModel):
+    """Container for tasks and their execution state."""
+
+    rootTask: Task
+    failedTasks: list[Task]
+    completedTasks: list[Task]
+    inProgressTasks: list[Task]
+    queuedTasks: list[Task]

--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -1,3 +1,19 @@
-from .orchestrator import AgentOrchestrator, Project, NODE_FACTORY
+from dataModel.project import Project
+from dataManagement.project_manager import (
+    save_project_state,
+    load_project_state,
+    latest_snapshot_path,
+)
+from .orchestrator import (
+    AgentOrchestrator,
+    NODE_FACTORY,
+)
 
-__all__ = ["AgentOrchestrator", "Project", "NODE_FACTORY"]
+__all__ = [
+    "AgentOrchestrator",
+    "Project",
+    "save_project_state",
+    "load_project_state",
+    "latest_snapshot_path",
+    "NODE_FACTORY",
+]

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable, Any
 from datetime import datetime
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import TypeAdapter
 
 from dataModel.task import Task, TaskType, TaskStatus
 from dataModel.model import AccessorType, Model

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 import orchestrator
 from dataModel.task import TaskType, Task
@@ -31,13 +32,25 @@ def test_orchestrator_runs_all_tasks(monkeypatch, tmp_path):
         raising=False,
     )
     monkeypatch.setattr(
+        orchestrator.orchestrator,
+        "NODE_FACTORY",
+        {TaskType.HLD: hld_factory, TaskType.IMPLEMENT: lambda acc: impl_factory()},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        orchestrator.orchestrator,
+        "NODE_FACTORY",
+        {TaskType.HLD: hld_factory, TaskType.IMPLEMENT: lambda acc: impl_factory()},
+        raising=False,
+    )
+    monkeypatch.setattr(
         orchestrator.AgentOrchestrator,
         "_get_accessor",
         lambda self, t: MockAccessor(),
     )
 
     orch = orchestrator.AgentOrchestrator(config_path=str(path))
-    project = orch.implement_project("proj")
+    project = orch.implement_project("proj", checkpoint_dir=str(tmp_path))
 
     assert [t.type for t in project.completedTasks] == [TaskType.HLD, TaskType.IMPLEMENT]
     assert not project.failedTasks
@@ -78,9 +91,68 @@ def test_spawn_rule_limit(monkeypatch, tmp_path):
     )
 
     orch = orchestrator.AgentOrchestrator(config_path=str(path))
-    project = orch.implement_project("proj")
+    project = orch.implement_project("proj", checkpoint_dir=str(tmp_path))
 
     completed_types = [t.type for t in project.completedTasks]
     assert completed_types.count(TaskType.IMPLEMENT) == 1
+    assert not project.failedTasks
+    assert not project.queuedTasks
+
+
+def test_resume_from_checkpoint(monkeypatch, tmp_path):
+    rules = {
+        "HLD": {"can_spawn": {"IMPLEMENT": 2}, "self_spawn": False},
+        "IMPLEMENT": {"can_spawn": {}, "self_spawn": False},
+    }
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(rules))
+    checkpoint_base = tmp_path
+
+    def hld_factory(_acc):
+        def node(state, config=None):
+            sub1 = Task(id="impl1", description="i1", type=TaskType.IMPLEMENT)
+            sub2 = Task(id="impl2", description="i2", type=TaskType.IMPLEMENT)
+            return DecomposedResponse(subtasks=[sub1, sub2]).model_dump()
+        return node
+
+    def impl_factory():
+        def node(state, config=None):
+            return ImplementedResponse(content="done").model_dump()
+        return node
+
+    monkeypatch.setattr(
+        orchestrator,
+        "NODE_FACTORY",
+        {TaskType.HLD: hld_factory, TaskType.IMPLEMENT: lambda acc: impl_factory()},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        orchestrator.AgentOrchestrator,
+        "_get_accessor",
+        lambda self, t: MockAccessor(),
+    )
+
+    save_calls = {"count": 0}
+    orig_save = orchestrator.save_project_state
+
+    def crash_save(project, path):
+        save_calls["count"] += 1
+        orig_save(project, path)
+        if save_calls["count"] == 1:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(orchestrator.orchestrator, "save_project_state", crash_save)
+
+    orch = orchestrator.AgentOrchestrator(config_path=str(path))
+    with pytest.raises(RuntimeError):
+        orch.implement_project("proj", checkpoint_dir=str(checkpoint_base))
+
+    monkeypatch.setattr(orchestrator.orchestrator, "save_project_state", orig_save)
+    run_dir = next(p for p in checkpoint_base.iterdir() if p.is_dir())
+    project = orch.resume_project(str(run_dir))
+
+    completed = [t.type for t in project.completedTasks]
+    assert completed.count(TaskType.IMPLEMENT) == 2
+    assert completed[0] == TaskType.HLD
     assert not project.failedTasks
     assert not project.queuedTasks

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -78,7 +78,7 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
     monkeypatch.setattr(AgentOrchestrator, "_get_accessor", lambda self, t: MockAccessor())
 
     orch = AgentOrchestrator(config_path=str(path))
-    project = orch.implement_project("build")
+    project = orch.implement_project("build", checkpoint_dir=str(tmp_path))
 
     completed = [t.type for t in project.completedTasks]
     assert completed == [

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,5 +1,4 @@
 import time
-import pytest
 
 from dataModel import Task, TaskType
 from dataModel.project import Project
@@ -71,7 +70,7 @@ def test_empty_project(tmp_path):
 
 def test_latest_snapshot_path(tmp_path):
     project = build_project()
-    snap1 = save_project_state(project, tmp_path)
+    save_project_state(project, tmp_path)
     time.sleep(0.01)
     project.completedTasks.append(project.rootTask)
     snap2 = save_project_state(project, tmp_path)

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,78 @@
+import time
+import pytest
+
+from dataModel import Task, TaskType
+from dataModel.project import Project
+from dataManagement.project_manager import (
+    save_project_state,
+    load_project_state,
+    latest_snapshot_path,
+)
+
+
+def build_project() -> Project:
+    root = Task(id="root", description="d", type=TaskType.HLD)
+    fail1 = Task(id="f1", description="f1", type=TaskType.REQUIREMENTS)
+    fail2 = Task(id="f2", description="f2", type=TaskType.RESEARCH)
+    comp1 = Task(id="c1", description="c1", type=TaskType.IMPLEMENT)
+    comp2 = Task(id="c2", description="c2", type=TaskType.IMPLEMENT)
+    queue1 = Task(id="q1", description="q1", type=TaskType.REVIEW)
+    queue2 = Task(id="q2", description="q2", type=TaskType.DEPLOY)
+    return Project(
+        rootTask=root,
+        failedTasks=[fail1, fail2],
+        completedTasks=[comp1, comp2],
+        inProgressTasks=[],
+        queuedTasks=[queue1, queue2],
+    )
+
+
+def build_project_with_inprogress() -> Project:
+    proj = build_project()
+    prog1 = Task(id="p1", description="p1", type=TaskType.LLD)
+    prog2 = Task(id="p2", description="p2", type=TaskType.TEST)
+    proj.inProgressTasks = [prog1, prog2]
+    return proj
+
+
+def build_empty_project() -> Project:
+    root = Task(id="root", description="d", type=TaskType.HLD)
+    return Project(
+        rootTask=root,
+        failedTasks=[],
+        completedTasks=[],
+        inProgressTasks=[],
+        queuedTasks=[],
+    )
+
+
+def test_save_and_load_round_trip(tmp_path):
+    project = build_project()
+    snapshot = save_project_state(project, tmp_path)
+    loaded = load_project_state(snapshot)
+    assert loaded == project
+
+
+def test_inprogress_requeued(tmp_path):
+    project = build_project_with_inprogress()
+    snapshot = save_project_state(project, tmp_path)
+    loaded = load_project_state(snapshot)
+    assert not loaded.inProgressTasks
+    ids = [t.id for t in project.inProgressTasks]
+    assert [t.id for t in loaded.queuedTasks[: len(ids)]] == ids
+
+
+def test_empty_project(tmp_path):
+    project = build_empty_project()
+    snap = save_project_state(project, tmp_path)
+    loaded = load_project_state(snap)
+    assert loaded == project
+
+
+def test_latest_snapshot_path(tmp_path):
+    project = build_project()
+    snap1 = save_project_state(project, tmp_path)
+    time.sleep(0.01)
+    project.completedTasks.append(project.rootTask)
+    snap2 = save_project_state(project, tmp_path)
+    assert latest_snapshot_path(tmp_path) == snap2


### PR DESCRIPTION
## Summary
- move project model to `dataModel` and add a rootTask field
- implement project saving/loading in new `dataManagement` package
- store checkpoints as timestamped JSON files in a run directory
- update orchestrator and CLI to use new checkpoint logic
- expand tests with checkpoint resume and project manager coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687866c95cb4832da1e666239c29b966