### PR TITLE
Refine implementer and e2e assertions

### DIFF
--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -13,7 +13,12 @@ from dataModel.model_response import (
 class Clarifier:
     """Decides whether the root task needs clarifying questions."""
 
-    PROMPT_TEMPLATE = "Clarify the following task if needed: {task}"
+    PROMPT_TEMPLATE = (
+        "You are checking if a project description needs any follow-up"
+        " questions. If it is clear enough to begin work, respond with the"
+        " phrase 'No clarification required'. Otherwise provide one concise"
+        " question to ask.\nTask: {task}"
+    )
 
     SCHEMA = FollowUpResponse | ImplementedResponse
 
@@ -27,6 +32,5 @@ class Clarifier:
         )
         return result
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
-        root_task: Task = state["root_task"]
-        return self.execute_task(root_task).model_dump()
+    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        return self.execute_task(task).model_dump()

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -33,6 +33,5 @@ class HLDDesigner:
         response: ModelResponse = self.llm_accessor.call_model(prompt, HLDDesigner.SCHEMA)
         return response
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
-        current_task: Task = state["task_queue"][0]
-        return self.execute_task(current_task).model_dump()
+    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        return self.execute_task(task).model_dump()

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from dataModel.task import Task
+
 from dataModel.model_response import ImplementedResponse
 
 
@@ -8,7 +10,7 @@ class Implementer:
 
     SCHEMA = ImplementedResponse
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
         resp = ImplementedResponse(
             content="def foo(): pass",
             artifacts=["foo.py"],

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -28,6 +28,5 @@ class LLDDesigner:
         response: ModelResponse = self.llm_accessor.call_model(prompt, LLDDesigner.SCHEMA)
         return response
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
-        current_task: Task = state["task_queue"][0]
-        return self.execute_task(current_task).model_dump()
+    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        return self.execute_task(task).model_dump()

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -30,6 +30,5 @@ class Researcher:
         result: ModelResponse = self.run_llm_agent(task)
         return result
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
-        current_task: Task = state["task_queue"][0]
-        return self.execute_task(current_task).model_dump()
+    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        return self.execute_task(task).model_dump()

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from dataModel.task import Task
+
 from dataModel.model_response import ImplementedResponse
 
 
@@ -8,6 +10,6 @@ class Tester:
 
     SCHEMA = ImplementedResponse
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+    def __call__(self, task: Task | None = None, config: dict[str, Any] | None = None) -> dict:
         resp = ImplementedResponse(content="pytest passed")
         return resp.model_dump()

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -158,7 +158,7 @@ class AgentOrchestrator:
             node = factory(accessor)
 
             try:
-                response_dict = node({"task_queue": [current_task], "root_task": project.rootTask})
+                response_dict = node(current_task)
                 response = adapter.validate_python(response_dict)
             except Exception as exc:  # noqa: BLE001
                 current_task.status = TaskStatus.FAILED

--- a/tests/agentNodes/test_implementer.py
+++ b/tests/agentNodes/test_implementer.py
@@ -2,11 +2,13 @@ from pydantic import TypeAdapter
 
 from agentNodes.implementer import Implementer
 from dataModel.model_response import ImplementedResponse
+from dataModel.task import Task, TaskType
 
 
 def test_implementer_returns_code():
     node = Implementer()
-    res = node({}, {})
+    task = Task(id="i1", description="impl", type=TaskType.IMPLEMENT)
+    res = node(task, {})
     parsed = TypeAdapter(Implementer.SCHEMA).validate_python(res)
     assert isinstance(parsed, ImplementedResponse)
     assert parsed.artifacts == ["foo.py"]

--- a/tests/agentNodes/test_tester.py
+++ b/tests/agentNodes/test_tester.py
@@ -2,11 +2,13 @@ from pydantic import TypeAdapter
 
 from agentNodes.tester import Tester
 from dataModel.model_response import ImplementedResponse
+from dataModel.task import Task, TaskType
 
 
 def test_tester_passed():
     node = Tester()
-    res = node({}, {})
+    task = Task(id="t1", description="test", type=TaskType.TEST)
+    res = node(task, {})
     parsed = TypeAdapter(Tester.SCHEMA).validate_python(res)
     assert isinstance(parsed, ImplementedResponse)
     assert parsed.content == "pytest passed"

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -15,13 +15,15 @@ def test_orchestrator_runs_all_tasks(monkeypatch, tmp_path):
     path.write_text(json.dumps(rules))
 
     def hld_factory(_acc):
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             sub = Task(id="impl", description="impl", type=TaskType.IMPLEMENT)
             return DecomposedResponse(subtasks=[sub]).model_dump()
         return node
 
     def impl_factory():
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             return ImplementedResponse(content="done").model_dump()
         return node
 
@@ -67,14 +69,16 @@ def test_spawn_rule_limit(monkeypatch, tmp_path):
     path.write_text(json.dumps(rules))
 
     def hld_factory(_acc):
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             sub1 = Task(id="impl1", description="impl", type=TaskType.IMPLEMENT)
             sub2 = Task(id="impl2", description="impl", type=TaskType.IMPLEMENT)
             return DecomposedResponse(subtasks=[sub1, sub2]).model_dump()
         return node
 
     def impl_factory():
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             return ImplementedResponse(content="done").model_dump()
         return node
 
@@ -109,14 +113,16 @@ def test_resume_from_checkpoint(monkeypatch, tmp_path):
     checkpoint_base = tmp_path
 
     def hld_factory(_acc):
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             sub1 = Task(id="impl1", description="i1", type=TaskType.IMPLEMENT)
             sub2 = Task(id="impl2", description="i2", type=TaskType.IMPLEMENT)
             return DecomposedResponse(subtasks=[sub1, sub2]).model_dump()
         return node
 
     def impl_factory():
-        def node(state, config=None):
+        def node(task, config=None):
+            assert isinstance(task, Task)
             return ImplementedResponse(content="done").model_dump()
         return node
 

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -65,10 +65,14 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
     )
     monkeypatch.setitem(NODE_FACTORY, TaskType.IMPLEMENT, lambda acc: Implementer())
 
-    def _review_node(state, config=None):
+    def _review_node(task, config=None):
+        assert isinstance(task, Task)
+        assert task.description == "review"
         return ImplementedResponse(content="reviewed").model_dump()
 
-    def _deploy_node(state, config=None):
+    def _deploy_node(task, config=None):
+        assert isinstance(task, Task)
+        assert task.description == "deploy"
         return ImplementedResponse(content="deployed", artifacts=["foo.py"]).model_dump()
 
     monkeypatch.setitem(NODE_FACTORY, TaskType.REVIEW, lambda acc: _review_node)


### PR DESCRIPTION
## Summary
- ensure `Implementer.__call__` always receives a Task
- verify task descriptions in end-to-end mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879851ff030832d9b37228dbb205203