### PR TITLE
Improve docs and add node docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ TreeAgent/
 └── README.md
 ```
 
+### Spawn Rules Configuration
+
+Agent spawning behaviour is controlled by a JSON file named
+`spawn_rules.json`. The orchestrator looks for this file in `config/` or the
+current working directory. Each task type lists which child types it may
+create and the maximum number allowed:
+
+```json
+{
+  "HLD": { "can_spawn": { "LLD": 5, "RESEARCH": 5, "TEST": 1 }, "self_spawn": false },
+  "LLD": { "can_spawn": { "IMPLEMENT": 5, "RESEARCH": 3, "TEST": 1 }, "self_spawn": false }
+}
+```
+
+Adjust these numbers to experiment with deeper or shallower trees.
+
 ## 🧪 Running Tests
 
 Install the optional dev dependencies to enable coverage reporting:
@@ -70,6 +86,19 @@ Execute the suite with coverage enabled:
 ```bash
 pytest --cov=src
 ```
+
+### Resuming From Checkpoints
+
+Each project run writes snapshots to the directory specified by
+`--checkpoint-dir` (defaults to `checkpoints`). If the process stops you can
+continue where it left off:
+
+```bash
+python -m treeagent.cli --resume checkpoints/20240101010101
+```
+
+The orchestrator will load the latest snapshot in that directory and resume
+processing the remaining tasks.
 
 ## 🛣️ Roadmap
 1. Minimal runnable demo – wire up a root → planner → executor flow that prints a toy result.

--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -23,9 +23,17 @@ class Clarifier:
     SCHEMA = FollowUpResponse | ImplementedResponse
 
     def __init__(self, llm_accessor: BaseModelAccessor):
+        """Create a Clarifier.
+
+        Parameters
+        ----------
+        llm_accessor:
+            Model accessor used to query the language model.
+        """
         self.llm_accessor = llm_accessor
 
     def execute_task(self, task: Task) -> ModelResponse:
+        """Ask the LLM whether the requirements need clarification."""
         result: ModelResponse = self.llm_accessor.call_model(
             prompt=Clarifier.PROMPT_TEMPLATE.format(task=task.description),
             schema=Clarifier.SCHEMA,
@@ -33,4 +41,5 @@ class Clarifier:
         return result
 
     def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        """Entry point for the orchestrator."""
         return self.execute_task(task).model_dump()

--- a/src/agentNodes/deployer.py
+++ b/src/agentNodes/deployer.py
@@ -9,6 +9,7 @@ class Deployer:
     SCHEMA = ImplementedResponse
 
     def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+        """Return a stub deployment result."""
         last = state["last_response"]
         resp = ImplementedResponse(content="deployed", artifacts=last.artifacts)
         return resp.model_dump()

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -23,9 +23,11 @@ class HLDDesigner:
     SCHEMA = DecomposedResponse | ImplementedResponse
 
     def __init__(self, llm_accessor: BaseModelAccessor):
+        """Create the designer with the given model accessor."""
         self.llm_accessor = llm_accessor
 
     def execute_task(self, task: Task) -> ModelResponse:
+        """Generate the high level design or subtasks for ``task``."""
         prompt = HLDDesigner.PROMPT_TEMPLATE.format(
             requirements=task.description,
             complexity=task.complexity,
@@ -34,4 +36,5 @@ class HLDDesigner:
         return response
 
     def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        """Execute and return a serialisable dict."""
         return self.execute_task(task).model_dump()

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -11,6 +11,7 @@ class Implementer:
     SCHEMA = ImplementedResponse
 
     def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        """Return a stub implementation for ``task``."""
         resp = ImplementedResponse(
             content="def foo(): pass",
             artifacts=["foo.py"],

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -18,9 +18,11 @@ class LLDDesigner:
     SCHEMA = ImplementedResponse
 
     def __init__(self, llm_accessor: BaseModelAccessor):
+        """Create the designer with the given model accessor."""
         self.llm_accessor = llm_accessor
 
     def execute_task(self, task: Task) -> ModelResponse:
+        """Generate low level design details for ``task``."""
         prompt = LLDDesigner.PROMPT_TEMPLATE.format(
             description=task.description,
             complexity=task.complexity,
@@ -29,4 +31,5 @@ class LLDDesigner:
         return response
 
     def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        """Execute and return a serialisable dict."""
         return self.execute_task(task).model_dump()

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -14,9 +14,11 @@ class Researcher:
     SCHEMA = ImplementedResponse
 
     def __init__(self, llm_accessor: BaseModelAccessor):
+        """Create the researcher with the given model accessor."""
         self.llm_accessor = llm_accessor
 
     def run_llm_agent(self, task: Task) -> ModelResponse:
+        """Invoke the underlying LLM with the web search tool."""
         prompt = Researcher.PROMPT_TEMPLATE.format(query=task.description)
         return self.llm_accessor.execute_task_with_tools(
             model="researcher",
@@ -26,9 +28,11 @@ class Researcher:
         )
 
     def execute_task(self, task: Task) -> ModelResponse:
+        """Perform research for ``task`` using web search."""
         task.tools = [WEB_SEARCH_TOOL]
         result: ModelResponse = self.run_llm_agent(task)
         return result
 
     def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+        """Execute and return a serialisable dict."""
         return self.execute_task(task).model_dump()

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -12,6 +12,7 @@ class Reviewer:
     SCHEMA = ImplementedResponse | FailedResponse
 
     def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+        """Approve implementations that contain a ``def`` statement."""
         last = state["last_response"]
         content = last.content or ""
         if "def" in content:

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -11,5 +11,6 @@ class Tester:
     SCHEMA = ImplementedResponse
 
     def __call__(self, task: Task | None = None, config: dict[str, Any] | None = None) -> dict:
+        """Return a stub test result."""
         resp = ImplementedResponse(content="pytest passed")
         return resp.model_dump()

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -139,6 +139,7 @@ class AgentOrchestrator:
         return self._run_loop(project, Path(checkpoint_dir))
 
     def _run_loop(self, project: Project, checkpoint_dir: Path) -> Project:
+        """Execute tasks sequentially until the queue is empty."""
         adapter = TypeAdapter(ModelResponse)
 
         while project.queuedTasks:


### PR DESCRIPTION
## Summary
- document spawn rules and checkpoint resuming
- add short docstrings to each node
- clarify run loop purpose in `AgentOrchestrator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cc5bd90c832db8cb98d91f839ec6