### PR TITLE
Enable clarifier stage and update tests

### DIFF
--- a/src/modelAccessors/anthropic_accessor.py
+++ b/src/modelAccessors/anthropic_accessor.py
@@ -27,6 +27,10 @@ class AnthropicAccessor(BaseModelAccessor):
             raise ValueError("No content in response")
             
         return TypeAdapter(ModelResponse).validate_json(content)
+
+    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - thin wrapper
+        """Convenience wrapper used by simple agent nodes."""
+        return self.prompt_model("claude-3-opus-20240229", "", prompt)
         
     def execute_task_with_tools(
         self,

--- a/src/modelAccessors/base_accessor.py
+++ b/src/modelAccessors/base_accessor.py
@@ -10,6 +10,11 @@ class BaseModelAccessor(ABC):
         pass
 
     @abstractmethod
+    def call_model(self, prompt: str, schema) -> Any:
+        """Simpler helper for tests and lightweight callers"""
+        pass
+
+    @abstractmethod
     def execute_task_with_tools(
         self,
         model: str,

--- a/src/modelAccessors/openai_accessor.py
+++ b/src/modelAccessors/openai_accessor.py
@@ -30,6 +30,10 @@ class OpenAIAccessor(BaseModelAccessor):
             
         return TypeAdapter(ModelResponse).validate_json(content) # type: ignore
 
+    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - thin wrapper
+        """Convenience wrapper used by simple agent nodes."""
+        return self.prompt_model("gpt-4", "", prompt)
+
     def execute_task_with_tools(
         self,
         model: str,

--- a/tests/agentNodes/test_researcher.py
+++ b/tests/agentNodes/test_researcher.py
@@ -15,6 +15,9 @@ class _StubAccessor(BaseModelAccessor):
     def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
         raise NotImplementedError()
 
+    def call_model(self, prompt: str, schema):  # pragma: no cover - unused
+        raise NotImplementedError()
+
     def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
         return self._result
 

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -42,6 +42,7 @@ def _research_exec(model: str, system_prompt: str, user_prompt: str, tools=None)
 
 
 RULES = {
+    "REQUIREMENTS": {"can_spawn": {"HLD": 1}, "self_spawn": False},
     "HLD": {"can_spawn": {"RESEARCH": 1, "IMPLEMENT": 1, "REVIEW": 1, "TEST": 1, "DEPLOY": 1}, "self_spawn": False},
     "RESEARCH": {"can_spawn": {}, "self_spawn": False},
     "IMPLEMENT": {"can_spawn": {}, "self_spawn": False},
@@ -90,6 +91,7 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
 
     completed = [t.type for t in project.completedTasks]
     assert completed == [
+        TaskType.REQUIREMENTS,
         TaskType.HLD,
         TaskType.RESEARCH,
         TaskType.IMPLEMENT,
@@ -100,7 +102,7 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
     assert not project.failedTasks
     assert not project.queuedTasks
 
-    root_task = project.completedTasks[0]
+    root_task = project.completedTasks[1]
     root_resp = project.taskResults[root_task.id]
     assert isinstance(root_resp, DecomposedResponse)
     assert [t.type for t in root_resp.subtasks] == [
@@ -112,7 +114,7 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
     ]
     assert all(t.parent_id == root_task.id for t in root_resp.subtasks)
 
-    research_task, impl_task, review_task, test_task, deploy_task = project.completedTasks[1:]
+    research_task, impl_task, review_task, test_task, deploy_task = project.completedTasks[2:]
     assert project.taskResults[research_task.id] == ImplementedResponse(artifacts=["https://example.com"])
     assert project.taskResults[impl_task.id] == ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
     assert project.taskResults[review_task.id] == ImplementedResponse(content="reviewed")


### PR DESCRIPTION
## Summary
- expose `call_model` on all accessors
- run the clarifier by starting projects with a requirements task
- queue an HLD task after requirements
- adjust orchestrator loop indentation
- update tests for new flow and add missing abstract method implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd3de019c832dbea5e15345e4d598