### PR TITLE
Introduce AgentNode abstract base class

### DIFF
--- a/src/agentNodes/__init__.py
+++ b/src/agentNodes/__init__.py
@@ -1,0 +1,5 @@
+"""Agent node implementations."""
+
+from .base import AgentNode
+
+__all__ = ["AgentNode"]

--- a/src/agentNodes/base.py
+++ b/src/agentNodes/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from dataModel.model_response import ModelResponse
+
+
+class AgentNode(ABC):
+    """Common interface for all agent nodes."""
+
+    SCHEMA: type[ModelResponse]
+
+    @abstractmethod
+    def execute_task(self, task: Any) -> ModelResponse:
+        """Perform the node's work and return a response."""
+        raise NotImplementedError
+
+    def __call__(self, task: Any, config: dict[str, Any] | None = None) -> dict:
+        """Execute the node and return a serialized response."""
+        return self.execute_task(task).model_dump()

--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -9,8 +9,10 @@ from dataModel.model_response import (
     ModelResponse,
 )
 
+from .base import AgentNode
 
-class Clarifier:
+
+class Clarifier(AgentNode):
     """Decides whether the root task needs clarifying questions."""
 
     PROMPT_TEMPLATE = (
@@ -32,5 +34,3 @@ class Clarifier:
         )
         return result
 
-    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
-        return self.execute_task(task).model_dump()

--- a/src/agentNodes/deployer.py
+++ b/src/agentNodes/deployer.py
@@ -1,14 +1,16 @@
 from typing import Any
 
-from dataModel.model_response import ImplementedResponse
+from dataModel.model_response import ImplementedResponse, ModelResponse
+
+from .base import AgentNode
 
 
-class Deployer:
+class Deployer(AgentNode):
     """Deploys the final artifact."""
 
     SCHEMA = ImplementedResponse
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+    def execute_task(self, state: dict[str, Any]) -> ModelResponse:
         last = state["last_response"]
         resp = ImplementedResponse(content="deployed", artifacts=last.artifacts)
-        return resp.model_dump()
+        return resp

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -9,8 +9,10 @@ from dataModel.model_response import (
     ImplementedResponse,
 )
 
+from .base import AgentNode
 
-class HLDDesigner:
+
+class HLDDesigner(AgentNode):
     """Node that requests a high-level design from an LLM."""
 
     PROMPT_TEMPLATE = (
@@ -33,5 +35,3 @@ class HLDDesigner:
         response: ModelResponse = self.llm_accessor.call_model(prompt, HLDDesigner.SCHEMA)
         return response
 
-    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
-        return self.execute_task(task).model_dump()

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,18 +1,19 @@
 from typing import Any
 
 from dataModel.task import Task
+from dataModel.model_response import ImplementedResponse, ModelResponse
 
-from dataModel.model_response import ImplementedResponse
+from .base import AgentNode
 
 
-class Implementer:
+class Implementer(AgentNode):
     """Generates code artifacts."""
 
     SCHEMA = ImplementedResponse
 
-    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
+    def execute_task(self, task: Task) -> ModelResponse:
         resp = ImplementedResponse(
             content="def foo(): pass",
             artifacts=["foo.py"],
         )
-        return resp.model_dump()
+        return resp

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -4,8 +4,10 @@ from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.task import Task
 from dataModel.model_response import ModelResponse, ImplementedResponse
 
+from .base import AgentNode
 
-class LLDDesigner:
+
+class LLDDesigner(AgentNode):
     """Produces low-level design documentation."""
 
     PROMPT_TEMPLATE = (
@@ -27,6 +29,3 @@ class LLDDesigner:
         )
         response: ModelResponse = self.llm_accessor.call_model(prompt, LLDDesigner.SCHEMA)
         return response
-
-    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
-        return self.execute_task(task).model_dump()

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -6,8 +6,10 @@ from dataModel.task import Task
 
 from tools.web_search import WEB_SEARCH_TOOL
 
+from .base import AgentNode
 
-class Researcher:
+
+class Researcher(AgentNode):
     """Gathers research artifacts using web search."""
 
     PROMPT_TEMPLATE = "{query}"
@@ -29,6 +31,3 @@ class Researcher:
         task.tools = [WEB_SEARCH_TOOL]
         result: ModelResponse = self.run_llm_agent(task)
         return result
-
-    def __call__(self, task: Task, config: dict[str, Any] | None = None) -> dict:
-        return self.execute_task(task).model_dump()

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -3,19 +3,22 @@ from typing import Any
 from dataModel.model_response import (
     ImplementedResponse,
     FailedResponse,
+    ModelResponse,
 )
 
+from .base import AgentNode
 
-class Reviewer:
+
+class Reviewer(AgentNode):
     """Reviews implemented code and either approves or rejects."""
 
     SCHEMA = ImplementedResponse | FailedResponse
 
-    def __call__(self, state: dict[str, Any], config: dict[str, Any] | None = None) -> dict:
+    def execute_task(self, state: dict[str, Any]) -> ModelResponse:
         last = state["last_response"]
         content = last.content or ""
         if "def" in content:
             resp = ImplementedResponse(content="LGTM", artifacts=last.artifacts)
         else:
             resp = FailedResponse(error_message="Style error")
-        return resp.model_dump()
+        return resp

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -2,14 +2,16 @@ from typing import Any
 
 from dataModel.task import Task
 
-from dataModel.model_response import ImplementedResponse
+from dataModel.model_response import ImplementedResponse, ModelResponse
+
+from .base import AgentNode
 
 
-class Tester:
+class Tester(AgentNode):
     """Runs tests on the implementation."""
 
     SCHEMA = ImplementedResponse
 
-    def __call__(self, task: Task | None = None, config: dict[str, Any] | None = None) -> dict:
+    def execute_task(self, task: Task | None = None) -> ModelResponse:
         resp = ImplementedResponse(content="pytest passed")
-        return resp.model_dump()
+        return resp


### PR DESCRIPTION
## Summary
- add `AgentNode` abstract class providing `execute_task` and `__call__`
- refactor all agent nodes to inherit from `AgentNode`
- expose `AgentNode` in agentNodes package

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd96232a4832d9992227917959f48