### PR TITLE
Add basic orchestrator logging

### DIFF
--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -1,0 +1,14 @@
+import logging
+
+
+def init_logger(name: str, verbose: bool = False) -> logging.Logger:
+    """Return a logger configured with a simple console handler."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    return logger


### PR DESCRIPTION
## Summary
- allow verbose logging through `AgentOrchestrator`
- report task execution details and outcomes
- log task completion in each outcome branch

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c7820ee8c832d9e0833d9f42d9f4b