### PR TITLE
Add LLM logic for Implementer and Tester

### DIFF
--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,18 +1,28 @@
 from agentNodes.base_node import AgentNode
+from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.task import Task
 
 from dataModel.model_response import ModelResponse, ImplementedResponse
 
 
 class Implementer(AgentNode):
-    """Generates code artifacts."""
+    """Generates code artifacts using an LLM accessor."""
+
+    PROMPT_TEMPLATE = (
+        "Generate python code based on the following description:\n"
+        "{description}\n"
+        "Respond with JSON matching the ImplementedResponse schema "
+        "summarising the implementation and listing any file names."
+    )
 
     SCHEMA = ImplementedResponse
 
+    def __init__(self, llm_accessor: BaseModelAccessor) -> None:
+        """Create the implementer with the given accessor."""
+        self.llm_accessor = llm_accessor
+
     def execute_task(self, task: Task) -> ModelResponse:
-        """Return a stub implementation for ``task``."""
-        resp = ImplementedResponse(
-            content="def foo(): pass",
-            artifacts=["foo.py"],
-        )
-        return resp
+        """Generate code for ``task`` using the LLM accessor."""
+        prompt = Implementer.PROMPT_TEMPLATE.format(description=task.description)
+        response: ModelResponse = self.llm_accessor.call_model(prompt, Implementer.SCHEMA)
+        return response

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -1,15 +1,27 @@
 from agentNodes.base_node import AgentNode
+from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.task import Task
 
-from dataModel.model_response import ModelResponse, ImplementedResponse
+from dataModel.model_response import ModelResponse, ImplementedResponse, FailedResponse
 
 
 class Tester(AgentNode):
-    """Runs tests on the implementation."""
+    """Runs tests on the implementation using an LLM accessor."""
 
-    SCHEMA = ImplementedResponse
+    PROMPT_TEMPLATE = (
+        "You are a software tester. Review the following implementation or "
+        "description and provide a short test result summary.\n{description}\n"
+        "Respond with JSON matching the ImplementedResponse schema."
+    )
+
+    SCHEMA = ImplementedResponse | FailedResponse
+
+    def __init__(self, llm_accessor: BaseModelAccessor) -> None:
+        self.llm_accessor = llm_accessor
 
     def execute_task(self, task: Task | None = None) -> ModelResponse:
-        """Return a stub test result."""
-        resp = ImplementedResponse(content="pytest passed")
-        return resp
+        """Return test results for ``task`` using the LLM accessor."""
+        desc = task.description if task else ""
+        prompt = Tester.PROMPT_TEMPLATE.format(description=desc)
+        response: ModelResponse = self.llm_accessor.call_model(prompt, Tester.SCHEMA)
+        return response

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -42,9 +42,9 @@ NODE_FACTORY: dict[TaskType, Callable[[BaseModelAccessor], Any]] = {
     TaskType.RESEARCH: lambda acc: Researcher(acc),
     TaskType.HLD: lambda acc: HLDDesigner(acc),
     TaskType.LLD: lambda acc: LLDDesigner(acc),
-    TaskType.IMPLEMENT: lambda acc: Implementer(),
+    TaskType.IMPLEMENT: lambda acc: Implementer(acc),
     TaskType.REVIEW: lambda acc: Reviewer(),
-    TaskType.TEST: lambda acc: Tester(),
+    TaskType.TEST: lambda acc: Tester(acc),
     TaskType.DEPLOY: lambda acc: Deployer(),
 }
 

--- a/tests/agentNodes/test_implementer.py
+++ b/tests/agentNodes/test_implementer.py
@@ -1,14 +1,29 @@
-from pydantic import TypeAdapter
-
 from agentNodes.implementer import Implementer
+from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.model_response import ImplementedResponse
 from dataModel.task import Task, TaskType
 
 
+class _StubAccessor(BaseModelAccessor):
+    def __init__(self, result: ImplementedResponse) -> None:
+        self._result = result
+
+    def call_model(self, prompt: str, schema):
+        return self._result
+
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
+        raise NotImplementedError()
+
+    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
+        raise NotImplementedError()
+
+
 def test_implementer_returns_code():
-    node = Implementer()
+    accessor = _StubAccessor(
+        ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
+    )
+    node = Implementer(accessor)
     task = Task(id="i1", description="impl", type=TaskType.IMPLEMENT)
-    res = node(task, {})
-    parsed = TypeAdapter(Implementer.SCHEMA).validate_python(res)
-    assert isinstance(parsed, ImplementedResponse)
-    assert parsed.artifacts == ["foo.py"]
+    res = node.execute_task(task)
+    assert isinstance(res, ImplementedResponse)
+    assert res.artifacts == ["foo.py"]

--- a/tests/agentNodes/test_tester.py
+++ b/tests/agentNodes/test_tester.py
@@ -1,14 +1,27 @@
-from pydantic import TypeAdapter
-
 from agentNodes.tester import Tester
+from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.model_response import ImplementedResponse
 from dataModel.task import Task, TaskType
 
 
+class _StubAccessor(BaseModelAccessor):
+    def __init__(self, result: ImplementedResponse) -> None:
+        self._result = result
+
+    def call_model(self, prompt: str, schema):
+        return self._result
+
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
+        raise NotImplementedError()
+
+    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
+        raise NotImplementedError()
+
+
 def test_tester_passed():
-    node = Tester()
+    accessor = _StubAccessor(ImplementedResponse(content="pytest passed"))
+    node = Tester(accessor)
     task = Task(id="t1", description="test", type=TaskType.TEST)
-    res = node(task, {})
-    parsed = TypeAdapter(Tester.SCHEMA).validate_python(res)
-    assert isinstance(parsed, ImplementedResponse)
-    assert parsed.content == "pytest passed"
+    res = node.execute_task(task)
+    assert isinstance(res, ImplementedResponse)
+    assert res.content == "pytest passed"


### PR DESCRIPTION
## Summary
- implement basic LLM-driven behaviour for `Implementer` and `Tester`
- pass accessor instances to these nodes in the orchestrator
- update unit tests for new constructors and behaviour
- adjust end-to-end tests to patch mock accessors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c78475820832d876401f23ccebd0b