### PR TITLE
Implement project file loader utilities

### DIFF
--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for indexing and searching project files."""
+
+from .file_loader import load_project_files, read_file
+
+__all__ = ["load_project_files", "read_file"]

--- a/src/search/config.py
+++ b/src/search/config.py
@@ -1,0 +1,7 @@
+"""Configuration for project file discovery."""
+
+from __future__ import annotations
+
+ALLOWED_EXTS: set[str] = {".py", ".md", ".txt", ".json", ".toml"}
+
+IGNORED_FOLDERS: set[str] = {".git", "__pycache__", "node_modules", "dist", "build"}

--- a/src/search/file_loader.py
+++ b/src/search/file_loader.py
@@ -1,0 +1,36 @@
+"""Utilities for discovering and reading project files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import config
+
+
+def load_project_files(base_dir: str | Path = ".") -> list[Path]:
+    """Recursively collect project files under ``base_dir``.
+
+    Only files whose suffix is listed in :data:`config.ALLOWED_EXTS` are
+    included. Paths containing any folder from :data:`config.IGNORED_FOLDERS`
+    or hidden directories are skipped.
+    """
+    base_path = Path(base_dir)
+    files: list[Path] = []
+    for path in base_path.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in config.ALLOWED_EXTS:
+            continue
+        if any(part.startswith(".") for part in path.parts):
+            continue
+        if any(ign in path.parts for ign in config.IGNORED_FOLDERS):
+            continue
+        files.append(path)
+    return files
+
+
+def read_file(path: str | Path) -> str:
+    """Return the UTF-8 contents of ``path`` with normalized newlines."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8", errors="ignore")
+    return text.replace("\r\n", "\n").replace("\r", "\n")

--- a/tests/test_file_loader.py
+++ b/tests/test_file_loader.py
@@ -1,0 +1,34 @@
+
+from search.file_loader import load_project_files, read_file
+
+
+def test_load_project_files_filters(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "code.py").write_text("pass")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "readme.txt").write_text("hi")
+
+    # ignored directories
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "mod.py").write_text("ignored")
+    (tmp_path / "src" / "__pycache__").mkdir()
+    (tmp_path / "src" / "__pycache__" / "cache.py").write_text("ignored")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("ignored")
+
+    # hidden directory
+    (tmp_path / "src" / ".hidden").mkdir()
+    (tmp_path / "src" / ".hidden" / "secret.py").write_text("ignored")
+
+    # unsupported extension
+    (tmp_path / "src" / "note.tmp").write_text("ignore")
+
+    files = load_project_files(tmp_path)
+    names = sorted(str(p.relative_to(tmp_path)) for p in files)
+    assert names == ["docs/readme.txt", "src/code.py"]
+
+
+def test_read_file_normalizes_newlines(tmp_path):
+    path = tmp_path / "file.py"
+    path.write_text("a\r\nb\rc")
+    assert read_file(path) == "a\nb\nc"


### PR DESCRIPTION
## Summary
- add `search` package for file discovery helpers
- support specifying allowed extensions and ignored directories
- implement `load_project_files` and `read_file` utilities
- test file loader behaviour and newline normalization

## Testing
- `ruff check .`
- `PYTHONPATH=src mypy --ignore-missing-imports src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885ea0bffc832da4c190b11f3a08bb