### PR TITLE
feat: allow selecting model accessor via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ cd TreeAgent
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e .                  # install package and CLI
 treeagent "hello world"           # prints skeleton task tree
+treeagent --model-type openai "hello"  # use OpenAI accessor by default
 ```
 
 > Heads-up: you’ll need an OpenAI (or other) API key in your shell once the first agent stubs call an LLM.

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -17,6 +17,7 @@ class Reviewer(AgentNode):
         """Approve implementations that contain a ``def`` statement."""
         last = data["last_response"]
         content = last.content or ""
+        resp: ModelResponse
         if "def" in content:
             resp = ImplementedResponse(content="LGTM", artifacts=last.artifacts)
         else:

--- a/src/cli.py
+++ b/src/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from .orchestrator import AgentOrchestrator
+from .dataModel.model import AccessorType
 
 
 def parse_args() -> argparse.Namespace:
@@ -26,6 +27,11 @@ def parse_args() -> argparse.Namespace:
         default="checkpoints",
         help="Directory to store project checkpoints",
     )
+    parser.add_argument(
+        "--model-type",
+        choices=[t.value for t in AccessorType],
+        help="Default model accessor to use for tasks",
+    )
     return parser.parse_args()
 
 
@@ -33,7 +39,10 @@ def main() -> None:
     """Entry point for the TreeAgent CLI."""
     args = parse_args()
 
-    orchestrator = AgentOrchestrator()
+    default_accessor = (
+        AccessorType(args.model_type) if args.model_type else None
+    )
+    orchestrator = AgentOrchestrator(default_accessor_type=default_accessor)
     if args.resume:
         project = orchestrator.resume_project(args.resume)
     elif args.prompt:

--- a/src/dataManagement/project_manager.py
+++ b/src/dataManagement/project_manager.py
@@ -11,7 +11,7 @@ def save_project_state(project: Project, directory: str | Path) -> Path:
     """Save ``project`` to ``directory`` with a timestamped filename."""
     dir_path = Path(directory)
     dir_path.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     file_path = dir_path / f"{timestamp}.json"
     tmp = file_path.with_suffix(file_path.suffix + ".tmp")
     tmp.write_text(json.dumps(project.model_dump(), indent=2))

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -161,7 +161,7 @@ class AgentOrchestrator:
 
     def _run_loop(self, project: Project, checkpoint_dir: Path) -> Project:
         """Execute tasks sequentially until the queue is empty."""
-        adapter = TypeAdapter(ModelResponse)
+        adapter: TypeAdapter[ModelResponse] = TypeAdapter(ModelResponse)
 
         while project.queuedTasks:
             current_task = project.queuedTasks.pop(0)

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -61,10 +61,12 @@ class AgentOrchestrator:
         *,
         verbose: bool = False,
         logger: logging.Logger | None = None,
+        default_accessor_type: AccessorType | None = None,
     ) -> None:
         """Load spawn rules and prepare orchestrator."""
         self.verbose = verbose
         self.logger = logger or init_logger(self.__class__.__name__, verbose)
+        self.default_accessor_type = default_accessor_type
 
         cfg_path: Path | None
         if config_path:
@@ -107,6 +109,11 @@ class AgentOrchestrator:
             spawned_count[sub.type.name] = spawned_count.get(sub.type.name, 0) + 1
             if spawned_count[sub.type.name] > limit:
                 continue
+            if (
+                self.default_accessor_type
+                and sub.model.accessor_type == AccessorType.MOCK
+            ):
+                sub.model = Model(accessor_type=self.default_accessor_type)
             sub.parent_id = parent.id
             sub.status = TaskStatus.PENDING
             out.append(sub)
@@ -221,6 +228,9 @@ class AgentOrchestrator:
                             id=f"{current_task.id}-hld",
                             description=current_task.description,
                             type=TaskType.HLD,
+                            model=Model(accessor_type=self.default_accessor_type)
+                            if self.default_accessor_type
+                            else Model(),
                         )
                         new_tasks = self._enqueue_subtasks(current_task, [hld])
                         project.queuedTasks.extend(new_tasks)
@@ -242,6 +252,9 @@ class AgentOrchestrator:
                             id=f"{current_task.id}-hld",
                             description=desc,
                             type=TaskType.HLD,
+                            model=Model(accessor_type=self.default_accessor_type)
+                            if self.default_accessor_type
+                            else Model(),
                         )
                         new_tasks = self._enqueue_subtasks(current_task, [hld])
                         project.queuedTasks.extend(new_tasks)
@@ -277,7 +290,9 @@ class AgentOrchestrator:
             id="root-task",
             type=TaskType.REQUIREMENTS,
             description=project_prompt,
-            model=Model(),  # Use default model
+            model=Model(accessor_type=self.default_accessor_type)
+            if self.default_accessor_type
+            else Model(),
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional `--model-type` CLI flag to choose default model accessor
- plumb chosen accessor through `AgentOrchestrator` to assign tasks the correct model
- save project checkpoints using UTC timestamps

## Testing
- `ruff check .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6e5b665c832dba043fd82e20f318