### PR TITLE
Ensure schema-driven validation across accessors

### DIFF
--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -23,6 +23,7 @@ class Researcher(AgentNode):
             model="researcher",
             system_prompt="You are a research assistant.",
             user_prompt=prompt,
+            schema=Researcher.SCHEMA,
             tools=task.tools,
         )
 

--- a/src/modelAccessors/base_accessor.py
+++ b/src/modelAccessors/base_accessor.py
@@ -5,7 +5,13 @@ from .data.tool import Tool
 
 class BaseModelAccessor(ABC):
     @abstractmethod
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> Any:
+    def prompt_model(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        schema,
+    ) -> Any:
         """Basic text prompting with no tools"""
         pass
 
@@ -20,6 +26,7 @@ class BaseModelAccessor(ABC):
         model: str,
         system_prompt: str,
         user_prompt: str,
+        schema,
         tools: Optional[list[Tool]] = None,
     ) -> Any:
         """

--- a/src/modelAccessors/mock_accessor.py
+++ b/src/modelAccessors/mock_accessor.py
@@ -1,9 +1,12 @@
 from .base_accessor import BaseModelAccessor, Tool
-from typing import Optional
+from typing import Optional, cast
+from pydantic import BaseModel, TypeAdapter
 from src.dataModel.model_response import (
     ModelResponse,
     DecomposedResponse,
     ImplementedResponse,
+    FollowUpResponse,
+    FailedResponse,
 )
 from src.dataModel.task import Task, TaskType
 
@@ -14,13 +17,52 @@ class MockAccessor(BaseModelAccessor):
         # Mock models that "support" tools
         self.tool_supported_models = ["mock-gpt-4", "mock-claude"]
 
-    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - simple wrapper
+    def call_model(self, prompt: str, schema: type[BaseModel]) -> ModelResponse:  # pragma: no cover - simple wrapper
         """Simpler call method used by node tests."""
-        return self.prompt_model("mock-gpt-4", "", prompt)
+        return self.prompt_model("mock-gpt-4", "", prompt, schema)
+
+    def prompt_model(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        schema: type[BaseModel],
+    ) -> ModelResponse:
+        _ = user_prompt  # prompt content not used for mock responses
+        response = self._build_response(schema)
+        validated = TypeAdapter(schema).validate_python(response.model_dump())
+        return cast(ModelResponse, validated)
     
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
-        # Return a mock decomposition for DECOMPOSE tasks
-        if "decompose" in user_prompt.lower() or "complex" in user_prompt.lower():
+    def execute_task_with_tools(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        schema: type[BaseModel],
+        tools: Optional[list[Tool]] = None,
+    ) -> ModelResponse:
+        _ = user_prompt  # prompt content not used for mock responses
+        response = self._build_response(schema)
+
+        if isinstance(response, ImplementedResponse):
+            if tools and self.supports_tools(model):
+                # Simulate using tools
+                tool_names = [tool.name for tool in tools]
+                response.content = (
+                    f"Mock task completed using tools: {', '.join(tool_names)}"
+                )
+            else:
+                response.content = "Mock task with tools completed"
+
+        validated = TypeAdapter(schema).validate_python(response.model_dump())
+        return cast(ModelResponse, validated)
+    
+    def supports_tools(self, model: str) -> bool:
+        """Mock tool support for certain models"""
+        return model in self.tool_supported_models
+
+    def _build_response(self, schema: type[BaseModel]) -> ModelResponse:
+        if issubclass(schema, DecomposedResponse):
             return DecomposedResponse(
                 subtasks=[
                     Task(
@@ -33,27 +75,20 @@ class MockAccessor(BaseModelAccessor):
                         type=TaskType.IMPLEMENT,
                         description="Create dashboard interface",
                     ),
-                ],
+                ]
             )
-        else:
-            return ImplementedResponse(content="Mock implementation completed")
-    
-    def execute_task_with_tools(
-        self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
-        tools: Optional[list[Tool]] = None,
-    ) -> ModelResponse:
-        if tools and self.supports_tools(model):
-            # Simulate using tools
-            tool_names = [tool.name for tool in tools]
-            return ImplementedResponse(
-                content=f"Mock task completed using tools: {', '.join(tool_names)}"
+
+        if issubclass(schema, FollowUpResponse):
+            return FollowUpResponse(
+                content="Mock follow-up required",
+                follow_up_ask=Task(
+                    id="mock-follow-up",
+                    type=TaskType.RESEARCH,
+                    description="Provide additional details",
+                ),
             )
-        else:
-            return ImplementedResponse(content="Mock task with tools completed")
-    
-    def supports_tools(self, model: str) -> bool:
-        """Mock tool support for certain models"""
-        return model in self.tool_supported_models
+
+        if issubclass(schema, FailedResponse):
+            return FailedResponse(error_message="Mock failure", retryable=False)
+
+        return ImplementedResponse(content="Mock implementation completed")

--- a/src/modelAccessors/openai_accessor.py
+++ b/src/modelAccessors/openai_accessor.py
@@ -1,7 +1,7 @@
 from os import environ
-from typing import Optional
+from typing import Any, Optional, cast
 from openai import OpenAI
-from pydantic import TypeAdapter
+from pydantic import BaseModel
 from .base_accessor import BaseModelAccessor, Tool
 from src.dataModel.model_response import ModelResponse
 
@@ -11,68 +11,75 @@ class OpenAIAccessor(BaseModelAccessor):
         # Models that support function calling/tools
         self.tool_supported_models = ["gpt-4", "gpt-4-turbo", "gpt-4o", "gpt-3.5-turbo-0125", "gpt-3.5-turbo"]
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
+    def prompt_model(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        schema: type[BaseModel],
+    ) -> ModelResponse:
         """
-        Sends a prompt to the specified OpenAI model and returns the response.
+        Sends a prompt to the specified OpenAI model and returns the validated response.
         """
-        response = self.client.chat.completions.create(
+        response = self.client.chat.completions.parse(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            response_format={"type": "json_object"}
+            response_format=schema,
         )
-        
-        content: str | None = response.choices[0].message.content
-        if not content:
-            raise ValueError("No content in response")
-            
-        return TypeAdapter(ModelResponse).validate_json(content) # type: ignore
 
-    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - thin wrapper
+        content = response.choices[0].message.parsed
+        if content is None:
+            raise ValueError("No content in response")
+
+        return cast(ModelResponse, content)
+
+    def call_model(self, prompt: str, schema: type[BaseModel]) -> ModelResponse:  # pragma: no cover - thin wrapper
         """Convenience wrapper used by simple agent nodes."""
-        return self.prompt_model("gpt-4", "", prompt)
+        return self.prompt_model("gpt-4", "", prompt, schema)
 
     def execute_task_with_tools(
         self,
         model: str,
         system_prompt: str,
         user_prompt: str,
+        schema: type[BaseModel],
         tools: Optional[list[Tool]] = None,
     ) -> ModelResponse:
         """
         Execute task with tools - using native function calling if supported
         """
         if not tools or not self.supports_tools(model):
-            return self.prompt_model(model, system_prompt, user_prompt)
-        
+            return self.prompt_model(model, system_prompt, user_prompt, schema)
+
         # Use native OpenAI function calling
         openai_tools = self._convert_to_openai_tools(tools)
-        
-        response = self.client.chat.completions.create(
+
+        response = self.client.chat.completions.parse(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
             tools=openai_tools,
-            response_format={"type": "json_object"}
+            response_format=schema,
         )
-        
-        content = response.choices[0].message.content
-        if not content:
+
+        content = response.choices[0].message.parsed
+        if content is None:
             raise ValueError("No content in response")
-            
-        return TypeAdapter(ModelResponse).validate_json(content)
+
+        return cast(ModelResponse, content)
     
     def supports_tools(self, model: str) -> bool:
         """Check if model supports native tools/function calling"""
         return model in self.tool_supported_models
         
-    def _convert_to_openai_tools(self, tools: list[Tool]) -> list[dict[str, object]]:
+    def _convert_to_openai_tools(self, tools: list[Tool]) -> list[dict[str, Any]]:
         """Convert our Tool objects to OpenAI's tool format"""
-        openai_tools: list[dict[str, object]] = []
+        openai_tools: list[dict[str, Any]] = []
         for tool in tools:
             openai_tools.append({
                 "type": "function",

--- a/tests/agentNodes/test_clarifier.py
+++ b/tests/agentNodes/test_clarifier.py
@@ -11,10 +11,12 @@ class _StubAccessor(BaseModelAccessor):
     def call_model(self, prompt: str, schema):
         raise NotImplementedError()
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_hld_designer.py
+++ b/tests/agentNodes/test_hld_designer.py
@@ -14,10 +14,12 @@ class _StubAccessor(BaseModelAccessor):
     def call_model(self, prompt: str, schema):
         return self._result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_implementer.py
+++ b/tests/agentNodes/test_implementer.py
@@ -11,10 +11,12 @@ class _StubAccessor(BaseModelAccessor):
     def call_model(self, prompt: str, schema):
         return self._result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):  # pragma: no cover - unused
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):  # pragma: no cover - unused
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_jury.py
+++ b/tests/agentNodes/test_jury.py
@@ -5,14 +5,14 @@ from src.modelAccessors.base_accessor import BaseModelAccessor
 
 
 class _StubAccessor(BaseModelAccessor):
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):
         raise NotImplementedError()
 
     def call_model(self, prompt: str, schema):  # pragma: no cover - unused
         raise NotImplementedError()
 
     def execute_task_with_tools(
-        self, model: str, system_prompt: str, user_prompt: str, tools=None
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
     ):  # pragma: no cover - unused
         raise NotImplementedError()
 

--- a/tests/agentNodes/test_lld_designer.py
+++ b/tests/agentNodes/test_lld_designer.py
@@ -14,10 +14,12 @@ class _StubAccessor(BaseModelAccessor):
     def call_model(self, prompt: str, schema):
         return self._result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_researcher.py
+++ b/tests/agentNodes/test_researcher.py
@@ -12,13 +12,15 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result):
         self._result = result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):
         raise NotImplementedError()
 
     def call_model(self, prompt: str, schema):  # pragma: no cover - unused
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):
         return self._result
 
 

--- a/tests/agentNodes/test_tester.py
+++ b/tests/agentNodes/test_tester.py
@@ -11,10 +11,12 @@ class _StubAccessor(BaseModelAccessor):
     def call_model(self, prompt: str, schema):
         return self._result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
+    def prompt_model(self, model: str, system_prompt: str, user_prompt: str, schema):  # pragma: no cover - unused
         raise NotImplementedError()
 
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
+    def execute_task_with_tools(
+        self, model: str, system_prompt: str, user_prompt: str, schema, tools=None
+    ):  # pragma: no cover - unused
         raise NotImplementedError()
 
 

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -182,6 +182,7 @@ def test_resume_from_checkpoint(monkeypatch, tmp_path):
         TaskType.IMPLEMENT: lambda acc: impl_factory(),
     }
     monkeypatch.setattr(orchestrator, "NODE_FACTORY", node_map, raising=False)
+    monkeypatch.setattr(orchestrator.orchestrator, "NODE_FACTORY", node_map, raising=False)
     monkeypatch.setattr(
         orchestrator.AgentOrchestrator,
         "_get_accessor",

--- a/tests/test_mock_accessor.py
+++ b/tests/test_mock_accessor.py
@@ -1,0 +1,20 @@
+from src.modelAccessors.mock_accessor import MockAccessor
+from src.dataModel.model_response import FollowUpResponse, FailedResponse
+
+
+def test_mock_accessor_follow_up_response():
+    accessor = MockAccessor()
+    response = accessor.prompt_model(
+        "mock-model", "", "irrelevant", FollowUpResponse
+    )
+    assert isinstance(response, FollowUpResponse)
+    assert response.follow_up_ask.description
+
+
+def test_mock_accessor_failed_response():
+    accessor = MockAccessor()
+    response = accessor.prompt_model(
+        "mock-model", "", "irrelevant", FailedResponse
+    )
+    assert isinstance(response, FailedResponse)
+    assert response.error_message

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -16,12 +16,12 @@ import json
 
 def _patch_accessor(accessor: MockAccessor, *, call_model=None, exec_tools=None) -> MockAccessor:
     if call_model:
-        def patched_prompt(model: str, system_prompt: str, user_prompt: str):
-            return call_model(user_prompt, None)
+        def patched_prompt(model: str, system_prompt: str, user_prompt: str, schema):
+            return call_model(user_prompt, schema)
         accessor.prompt_model = patched_prompt  # type: ignore
     if exec_tools:
-        def patched_exec(model: str, system_prompt: str, user_prompt: str, tools=None):
-            return exec_tools(model, system_prompt, user_prompt, tools)
+        def patched_exec(model: str, system_prompt: str, user_prompt: str, schema, tools=None):
+            return exec_tools(model, system_prompt, user_prompt, schema, tools)
         accessor.execute_task_with_tools = patched_exec  # type: ignore
     return accessor
 
@@ -37,7 +37,7 @@ def _hld_call_model(prompt: str, schema):
     return DecomposedResponse(subtasks=subtasks)
 
 
-def _research_exec(model: str, system_prompt: str, user_prompt: str, tools=None):
+def _research_exec(model: str, system_prompt: str, user_prompt: str, schema, tools=None):
     return ImplementedResponse(artifacts=["https://example.com"])
 
 


### PR DESCRIPTION
## Summary
- pass schemas directly to OpenAI `response_format` and parse structured responses

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d5293c0c4832dbddf3589d0c74611