### PR TITLE
Ensure schema-driven validation across accessors

### DIFF
--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -1,12 +1,10 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
 from src.dataModel.task import Task
-from src.dataModel.model_response import (
-    FollowUpResponse,
-    ImplementedResponse,
-    ModelResponse,
-)
+from src.dataModel.model_response import ClarifierResponse
 
 
 class Clarifier(AgentNode):
@@ -19,7 +17,8 @@ class Clarifier(AgentNode):
         " question to ask.\nTask: {task}"
     )
 
-    SCHEMA = FollowUpResponse | ImplementedResponse
+    ADAPTER = TypeAdapter(ClarifierResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
         """Create a Clarifier.
@@ -31,11 +30,11 @@ class Clarifier(AgentNode):
         """
         self.llm_accessor = llm_accessor
 
-    def execute_task(self, data: Task) -> ModelResponse:
+    def execute_task(self, data: Task) -> ClarifierResponse:
         """Ask the LLM whether the requirements need clarification."""
-        result: ModelResponse = self.llm_accessor.call_model(
+        return self.llm_accessor.call_model(
             prompt=Clarifier.PROMPT_TEMPLATE.format(task=data.description),
+            adapter=Clarifier.ADAPTER,
             schema=Clarifier.SCHEMA,
         )
-        return result
 

--- a/src/agentNodes/clarifier.py
+++ b/src/agentNodes/clarifier.py
@@ -1,10 +1,12 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
 from src.dataModel.task import Task
-from src.dataModel.model_response import ClarifierResponse
+from src.dataModel.model_response import ClarifierResponse, ModelResponse
 
 
 class Clarifier(AgentNode):
@@ -17,7 +19,9 @@ class Clarifier(AgentNode):
         " question to ask.\nTask: {task}"
     )
 
-    ADAPTER = TypeAdapter(ClarifierResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(ClarifierResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
@@ -32,9 +36,10 @@ class Clarifier(AgentNode):
 
     def execute_task(self, data: Task) -> ClarifierResponse:
         """Ask the LLM whether the requirements need clarification."""
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt=Clarifier.PROMPT_TEMPLATE.format(task=data.description),
             adapter=Clarifier.ADAPTER,
             schema=Clarifier.SCHEMA,
         )
+        return cast(ClarifierResponse, resp)
 

--- a/src/agentNodes/deployer.py
+++ b/src/agentNodes/deployer.py
@@ -1,15 +1,18 @@
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
-from src.dataModel.model_response import ImplementedResponse, ModelResponse
+from src.dataModel.model_response import ImplementedResponse
 
 
 class Deployer(AgentNode):
     """Deploys the final artifact."""
 
-    SCHEMA = ImplementedResponse
+    ADAPTER = TypeAdapter(ImplementedResponse)
+    SCHEMA = ADAPTER.json_schema()
 
-    def execute_task(self, data: dict[str, Any]) -> ModelResponse:
+    def execute_task(self, data: dict[str, Any]) -> ImplementedResponse:
         """Return a stub deployment result."""
         last = data["last_response"]
         resp = ImplementedResponse(content="deployed", artifacts=last.artifacts)

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -1,12 +1,10 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
 from src.dataModel.task import Task
-from src.dataModel.model_response import (
-    ModelResponse,
-    DecomposedResponse,
-    ImplementedResponse,
-)
+from src.dataModel.model_response import DesignerResponse
 
 
 class HLDDesigner(AgentNode):
@@ -19,18 +17,22 @@ class HLDDesigner(AgentNode):
         "Provide at most 5 subtasks using only the types: LLD, RESEARCH, TEST."
     )
 
-    SCHEMA = DecomposedResponse | ImplementedResponse
+    ADAPTER = TypeAdapter(DesignerResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
         """Create the designer with the given model accessor."""
         self.llm_accessor = llm_accessor
 
-    def execute_task(self, data: Task) -> ModelResponse:
+    def execute_task(self, data: Task) -> DesignerResponse:
         """Generate the high level design or subtasks for ``task``."""
         prompt = HLDDesigner.PROMPT_TEMPLATE.format(
             requirements=data.description,
             complexity=data.complexity,
         )
-        response: ModelResponse = self.llm_accessor.call_model(prompt, HLDDesigner.SCHEMA)
-        return response
+        return self.llm_accessor.call_model(
+            prompt,
+            adapter=HLDDesigner.ADAPTER,
+            schema=HLDDesigner.SCHEMA,
+        )
 

--- a/src/agentNodes/hld_designer.py
+++ b/src/agentNodes/hld_designer.py
@@ -1,10 +1,12 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
 from src.dataModel.task import Task
-from src.dataModel.model_response import DesignerResponse
+from src.dataModel.model_response import DesignerResponse, ModelResponse
 
 
 class HLDDesigner(AgentNode):
@@ -17,7 +19,9 @@ class HLDDesigner(AgentNode):
         "Provide at most 5 subtasks using only the types: LLD, RESEARCH, TEST."
     )
 
-    ADAPTER = TypeAdapter(DesignerResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(DesignerResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
@@ -30,9 +34,10 @@ class HLDDesigner(AgentNode):
             requirements=data.description,
             complexity=data.complexity,
         )
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt,
             adapter=HLDDesigner.ADAPTER,
             schema=HLDDesigner.SCHEMA,
         )
+        return cast(DesignerResponse, resp)
 

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,10 +1,12 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
 
-from src.dataModel.model_response import ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse, ModelResponse
 
 
 class Implementer(AgentNode):
@@ -17,7 +19,9 @@ class Implementer(AgentNode):
         "summarising the implementation and listing any file names."
     )
 
-    ADAPTER = TypeAdapter(ImplementedResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(ImplementedResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor) -> None:
@@ -27,8 +31,9 @@ class Implementer(AgentNode):
     def execute_task(self, data: Task) -> ImplementedResponse:
         """Generate code for ``task`` using the LLM accessor."""
         prompt = Implementer.PROMPT_TEMPLATE.format(description=data.description)
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt,
             adapter=Implementer.ADAPTER,
             schema=Implementer.SCHEMA,
         )
+        return cast(ImplementedResponse, resp)

--- a/src/agentNodes/implementer.py
+++ b/src/agentNodes/implementer.py
@@ -1,8 +1,10 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
 
-from src.dataModel.model_response import ModelResponse, ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse
 
 
 class Implementer(AgentNode):
@@ -15,14 +17,18 @@ class Implementer(AgentNode):
         "summarising the implementation and listing any file names."
     )
 
-    SCHEMA = ImplementedResponse
+    ADAPTER = TypeAdapter(ImplementedResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor) -> None:
         """Create the implementer with the given accessor."""
         self.llm_accessor = llm_accessor
 
-    def execute_task(self, data: Task) -> ModelResponse:
+    def execute_task(self, data: Task) -> ImplementedResponse:
         """Generate code for ``task`` using the LLM accessor."""
         prompt = Implementer.PROMPT_TEMPLATE.format(description=data.description)
-        response: ModelResponse = self.llm_accessor.call_model(prompt, Implementer.SCHEMA)
-        return response
+        return self.llm_accessor.call_model(
+            prompt,
+            adapter=Implementer.ADAPTER,
+            schema=Implementer.SCHEMA,
+        )

--- a/src/agentNodes/jury.py
+++ b/src/agentNodes/jury.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from src.agentNodes.base_node import AgentNode
-from src.dataModel.model_response import ImplementedResponse, ModelResponse
+from src.dataModel.model_response import ImplementedResponse
 from src.dataModel.task import Task
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
@@ -18,6 +18,6 @@ class Jury(AgentNode):
     def __init__(self, accessor: BaseModelAccessor) -> None:
         self.accessor = accessor
 
-    def execute_task(self, data: Task | None = None) -> ModelResponse:
+    def execute_task(self, data: Task | None = None) -> ImplementedResponse:
         """Return a placeholder verdict for ``task``."""
         return ImplementedResponse(content="jury verdict")

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -1,7 +1,9 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
-from src.dataModel.model_response import ModelResponse, ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse
 
 
 class LLDDesigner(AgentNode):
@@ -14,18 +16,22 @@ class LLDDesigner(AgentNode):
         "Return at most 5 subtasks using only the types: IMPLEMENT, RESEARCH, TEST."
     )
 
-    SCHEMA = ImplementedResponse
+    ADAPTER = TypeAdapter(ImplementedResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
         """Create the designer with the given model accessor."""
         self.llm_accessor = llm_accessor
 
-    def execute_task(self, data: Task) -> ModelResponse:
+    def execute_task(self, data: Task) -> ImplementedResponse:
         """Generate low level design details for ``task``."""
         prompt = LLDDesigner.PROMPT_TEMPLATE.format(
             description=data.description,
             complexity=data.complexity,
         )
-        response: ModelResponse = self.llm_accessor.call_model(prompt, LLDDesigner.SCHEMA)
-        return response
+        return self.llm_accessor.call_model(
+            prompt,
+            adapter=LLDDesigner.ADAPTER,
+            schema=LLDDesigner.SCHEMA,
+        )
 

--- a/src/agentNodes/lld_designer.py
+++ b/src/agentNodes/lld_designer.py
@@ -1,9 +1,11 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
-from src.dataModel.model_response import ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse, ModelResponse
 
 
 class LLDDesigner(AgentNode):
@@ -16,7 +18,9 @@ class LLDDesigner(AgentNode):
         "Return at most 5 subtasks using only the types: IMPLEMENT, RESEARCH, TEST."
     )
 
-    ADAPTER = TypeAdapter(ImplementedResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(ImplementedResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
@@ -29,9 +33,10 @@ class LLDDesigner(AgentNode):
             description=data.description,
             complexity=data.complexity,
         )
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt,
             adapter=LLDDesigner.ADAPTER,
             schema=LLDDesigner.SCHEMA,
         )
+        return cast(ImplementedResponse, resp)
 

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -1,6 +1,8 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
-from src.dataModel.model_response import ModelResponse, ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse
 from src.dataModel.task import Task
 
 from src.tools.web_search import WEB_SEARCH_TOOL
@@ -10,25 +12,27 @@ class Researcher(AgentNode):
     """Gathers research artifacts using web search."""
 
     PROMPT_TEMPLATE = "{query}"
-    SCHEMA = ImplementedResponse
+    ADAPTER = TypeAdapter(ImplementedResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
         """Create the researcher with the given model accessor."""
         self.llm_accessor = llm_accessor
 
-    def run_llm_agent(self, task: Task) -> ModelResponse:
+    def run_llm_agent(self, task: Task) -> ImplementedResponse:
         """Invoke the underlying LLM with the web search tool."""
         prompt = Researcher.PROMPT_TEMPLATE.format(query=task.description)
-        return self.llm_accessor.execute_task_with_tools(
+        return self.llm_accessor.call_model(
+            prompt,
             model="researcher",
             system_prompt="You are a research assistant.",
-            user_prompt=prompt,
+            adapter=Researcher.ADAPTER,
+            schema=Researcher.SCHEMA,
             tools=task.tools,
         )
 
-    def execute_task(self, data: Task) -> ModelResponse:
+    def execute_task(self, data: Task) -> ImplementedResponse:
         """Perform research for ``task`` using web search."""
         data.tools = [WEB_SEARCH_TOOL]
-        result: ModelResponse = self.run_llm_agent(data)
-        return result
+        return self.run_llm_agent(data)
 

--- a/src/agentNodes/researcher.py
+++ b/src/agentNodes/researcher.py
@@ -1,8 +1,10 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
-from src.dataModel.model_response import ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse, ModelResponse
 from src.dataModel.task import Task
 
 from src.tools.web_search import WEB_SEARCH_TOOL
@@ -12,7 +14,9 @@ class Researcher(AgentNode):
     """Gathers research artifacts using web search."""
 
     PROMPT_TEMPLATE = "{query}"
-    ADAPTER = TypeAdapter(ImplementedResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(ImplementedResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor):
@@ -22,7 +26,7 @@ class Researcher(AgentNode):
     def run_llm_agent(self, task: Task) -> ImplementedResponse:
         """Invoke the underlying LLM with the web search tool."""
         prompt = Researcher.PROMPT_TEMPLATE.format(query=task.description)
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt,
             model="researcher",
             system_prompt="You are a research assistant.",
@@ -30,6 +34,7 @@ class Researcher(AgentNode):
             schema=Researcher.SCHEMA,
             tools=task.tools,
         )
+        return cast(ImplementedResponse, resp)
 
     def execute_task(self, data: Task) -> ImplementedResponse:
         """Perform research for ``task`` using web search."""

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -13,7 +13,7 @@ from src.dataModel.model_response import (
 class Reviewer(AgentNode):
     """Reviews implemented code and either approves or rejects."""
 
-    ADAPTER = TypeAdapter(TesterResponse)
+    ADAPTER: TypeAdapter[TesterResponse] = TypeAdapter(TesterResponse)
     SCHEMA = ADAPTER.json_schema()
 
     def execute_task(self, data: dict[str, Any]) -> TesterResponse:

--- a/src/agentNodes/reviewer.py
+++ b/src/agentNodes/reviewer.py
@@ -1,23 +1,26 @@
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.dataModel.model_response import (
     ImplementedResponse,
     FailedResponse,
-    ModelResponse,
+    TesterResponse,
 )
 
 
 class Reviewer(AgentNode):
     """Reviews implemented code and either approves or rejects."""
 
-    SCHEMA = ImplementedResponse | FailedResponse
+    ADAPTER = TypeAdapter(TesterResponse)
+    SCHEMA = ADAPTER.json_schema()
 
-    def execute_task(self, data: dict[str, Any]) -> ModelResponse:
+    def execute_task(self, data: dict[str, Any]) -> TesterResponse:
         """Approve implementations that contain a ``def`` statement."""
         last = data["last_response"]
         content = last.content or ""
-        resp: ModelResponse
+        resp: TesterResponse
         if "def" in content:
             resp = ImplementedResponse(content="LGTM", artifacts=last.artifacts)
         else:

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -1,8 +1,10 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
 
-from src.dataModel.model_response import ModelResponse, ImplementedResponse, FailedResponse
+from src.dataModel.model_response import TesterResponse
 
 
 class Tester(AgentNode):
@@ -14,14 +16,18 @@ class Tester(AgentNode):
         "Respond with JSON matching the ImplementedResponse schema."
     )
 
-    SCHEMA = ImplementedResponse | FailedResponse
+    ADAPTER = TypeAdapter(TesterResponse)
+    SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor) -> None:
         self.llm_accessor = llm_accessor
 
-    def execute_task(self, data: Task | None = None) -> ModelResponse:
+    def execute_task(self, data: Task | None = None) -> TesterResponse:
         """Return test results for ``task`` using the LLM accessor."""
         desc = data.description if data else ""
         prompt = Tester.PROMPT_TEMPLATE.format(description=desc)
-        response: ModelResponse = self.llm_accessor.call_model(prompt, Tester.SCHEMA)
-        return response
+        return self.llm_accessor.call_model(
+            prompt,
+            adapter=Tester.ADAPTER,
+            schema=Tester.SCHEMA,
+        )

--- a/src/agentNodes/tester.py
+++ b/src/agentNodes/tester.py
@@ -1,10 +1,12 @@
+from typing import cast
+
 from pydantic import TypeAdapter
 
 from src.agentNodes.base_node import AgentNode
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task
 
-from src.dataModel.model_response import TesterResponse
+from src.dataModel.model_response import ModelResponse, TesterResponse
 
 
 class Tester(AgentNode):
@@ -16,7 +18,9 @@ class Tester(AgentNode):
         "Respond with JSON matching the ImplementedResponse schema."
     )
 
-    ADAPTER = TypeAdapter(TesterResponse)
+    ADAPTER: TypeAdapter[ModelResponse] = cast(
+        TypeAdapter[ModelResponse], TypeAdapter(TesterResponse)
+    )
     SCHEMA = ADAPTER.json_schema()
 
     def __init__(self, llm_accessor: BaseModelAccessor) -> None:
@@ -26,8 +30,9 @@ class Tester(AgentNode):
         """Return test results for ``task`` using the LLM accessor."""
         desc = data.description if data else ""
         prompt = Tester.PROMPT_TEMPLATE.format(description=desc)
-        return self.llm_accessor.call_model(
+        resp = self.llm_accessor.call_model(
             prompt,
             adapter=Tester.ADAPTER,
             schema=Tester.SCHEMA,
         )
+        return cast(TesterResponse, resp)

--- a/src/dataModel/__init__.py
+++ b/src/dataModel/__init__.py
@@ -4,22 +4,26 @@ from .task import TaskType, Task, TaskStatus
 from .project import Project
 from .model_response import (
     ModelResponse,
-    ModelResponseType,
     DecomposedResponse,
     ImplementedResponse,
     FollowUpResponse,
     FailedResponse,
+    ClarifierResponse,
+    DesignerResponse,
+    TesterResponse,
 )
 
 __all__ = [
     "TaskType",
     "Task",
     "ModelResponse",
-    "ModelResponseType",
     "DecomposedResponse",
     "ImplementedResponse",
     "FollowUpResponse",
     "FailedResponse",
+    "ClarifierResponse",
+    "DesignerResponse",
+    "TesterResponse",
     "TaskStatus",
     "Project",
 ]

--- a/src/dataModel/model_response.py
+++ b/src/dataModel/model_response.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Literal, Optional, TypeAlias, Union
 
 from .task import Task
 
 from pydantic import BaseModel, Field
+
+
+class _BaseResponse(BaseModel):
+    content: Optional[str] = None
+    artifacts: list[str] = []
+    model_config = {"extra": "forbid"}
 
 
 class ModelResponseType(str, Enum):
@@ -15,41 +21,51 @@ class ModelResponseType(str, Enum):
     FAILED = "failed"
 
 
-class _BaseResponse(BaseModel):
-    content: Optional[str] = None
-    artifacts: list[str] = []
-
-
 class DecomposedResponse(_BaseResponse):
-    response_type: Literal[ModelResponseType.DECOMPOSED] = Field(
+    type: Literal[ModelResponseType.DECOMPOSED] = Field(
         default=ModelResponseType.DECOMPOSED
     )
     subtasks: list[Task]
 
 
 class ImplementedResponse(_BaseResponse):
-    response_type: Literal[ModelResponseType.IMPLEMENTED] = Field(
+    type: Literal[ModelResponseType.IMPLEMENTED] = Field(
         default=ModelResponseType.IMPLEMENTED
     )
 
 
 class FollowUpResponse(_BaseResponse):
-    response_type: Literal[ModelResponseType.FOLLOW_UP_REQUIRED] = Field(
+    type: Literal[ModelResponseType.FOLLOW_UP_REQUIRED] = Field(
         default=ModelResponseType.FOLLOW_UP_REQUIRED
     )
     follow_up_ask: Task
 
 
 class FailedResponse(_BaseResponse):
-    response_type: Literal[ModelResponseType.FAILED] = Field(
+    type: Literal[ModelResponseType.FAILED] = Field(
         default=ModelResponseType.FAILED
     )
     error_message: str
     retryable: bool = False
 
 
-ModelResponse = Annotated[
+ModelResponse: TypeAlias = Annotated[
     Union[DecomposedResponse, ImplementedResponse, FollowUpResponse, FailedResponse],
-    Field(discriminator="response_type"),
+    Field(discriminator="type"),
+]
+
+ClarifierResponse: TypeAlias = Annotated[
+    Union[FollowUpResponse, ImplementedResponse],
+    Field(discriminator="type"),
+]
+
+DesignerResponse: TypeAlias = Annotated[
+    Union[DecomposedResponse, ImplementedResponse],
+    Field(discriminator="type"),
+]
+
+TesterResponse: TypeAlias = Annotated[
+    Union[ImplementedResponse, FailedResponse],
+    Field(discriminator="type"),
 ]
 

--- a/src/modelAccessors/__init__.py
+++ b/src/modelAccessors/__init__.py
@@ -1,8 +1,2 @@
 # Model accessors package
-from .base_accessor import BaseModelAccessor
-from .data.tool import Tool
-
-__all__ = [
-    "BaseModelAccessor",
-    "Tool",
-]
+__all__: list[str] = []

--- a/src/modelAccessors/anthropic_accessor.py
+++ b/src/modelAccessors/anthropic_accessor.py
@@ -1,7 +1,9 @@
 from os import environ
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
+
 from pydantic import TypeAdapter
 from anthropic import Anthropic
+
 from .base_accessor import BaseModelAccessor, Tool
 from src.dataModel.model_response import ModelResponse
 
@@ -11,62 +13,48 @@ class AnthropicAccessor(BaseModelAccessor):
         # Models with tool support
         self.tool_supported_models = ["claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-5-sonnet-20240620"]
         
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
-        """Basic text prompting for Claude models"""
-        response = self.client.messages.create(
-            model=model,
-            max_tokens=4096,
-            system=system_prompt,
-            messages=[
-                {"role": "user", "content": user_prompt}
-            ]
-        )
-        
-        content = response.content[0].text
-        if not content:
-            raise ValueError("No content in response")
-            
-        return TypeAdapter(ModelResponse).validate_json(content)
-
-    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - thin wrapper
-        """Convenience wrapper used by simple agent nodes."""
-        return self.prompt_model("claude-3-opus-20240229", "", prompt)
-        
-    def execute_task_with_tools(
+    def call_model(
         self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ModelResponse],
+        schema: dict,
+        model: str = "claude-3-opus-20240229",
+        system_prompt: str = "",
         tools: Optional[list[Tool]] = None,
     ) -> ModelResponse:
-        """Execute task with tools - native tools if supported"""
-        if not tools:
-            return self.prompt_model(model, system_prompt, user_prompt)
-            
-        if self.supports_tools(model):
-            # Use Claude's native tool use
-            claude_tools = self._convert_to_claude_tools(tools)
-            
+        if tools:
+            if self.supports_tools(model):
+                claude_tools = self._convert_to_claude_tools(tools)
+                response = self.client.messages.create(
+                    model=model,
+                    max_tokens=4096,
+                    system=system_prompt,
+                    messages=[{"role": "user", "content": prompt}],
+                    tools=claude_tools,
+                )
+            else:
+                tools_description = self._format_tools_for_prompt(tools)
+                enhanced_system_prompt = f"{system_prompt}\n\nAvailable tools:\n{tools_description}"
+                response = self.client.messages.create(
+                    model=model,
+                    max_tokens=4096,
+                    system=enhanced_system_prompt,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+        else:
             response = self.client.messages.create(
                 model=model,
                 max_tokens=4096,
                 system=system_prompt,
-                messages=[
-                    {"role": "user", "content": user_prompt}
-                ],
-                tools=claude_tools
+                messages=[{"role": "user", "content": prompt}],
             )
-            
-            content = response.content[0].text
-            if not content:
-                raise ValueError("No content in response")
-                
-            return TypeAdapter(ModelResponse).validate_json(content)
-        else:
-            # Fallback for models without tool support
-            tools_description = self._format_tools_for_prompt(tools)
-            enhanced_system_prompt = f"{system_prompt}\n\nAvailable tools:\n{tools_description}"
-            return self.prompt_model(model, enhanced_system_prompt, user_prompt)
+
+        content = response.content[0].text
+        if not content:
+            raise ValueError("No content in response")
+
+        return adapter.validate_json(content)
     
     def supports_tools(self, model: str) -> bool:
         """Check if model supports native tool use"""

--- a/src/modelAccessors/base_accessor.py
+++ b/src/modelAccessors/base_accessor.py
@@ -1,34 +1,30 @@
-from abc import ABC, abstractmethod
-from typing import Any, Optional
+from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pydantic import TypeAdapter
+
+from src.dataModel.model_response import ModelResponse
 from .data.tool import Tool
+
 
 class BaseModelAccessor(ABC):
     @abstractmethod
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> Any:
-        """Basic text prompting with no tools"""
-        pass
-
-    @abstractmethod
-    def call_model(self, prompt: str, schema) -> Any:
-        """Simpler helper for tests and lightweight callers"""
-        pass
-
-    @abstractmethod
-    def execute_task_with_tools(
+    def call_model(
         self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ModelResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
         tools: Optional[list[Tool]] = None,
-    ) -> Any:
-        """
-        Execute a task with available tools. The accessor handles whether to:
-        1. Use native tool calling (for agentic models)
-        2. Simulate tool execution through chat (for chat-only models)
-        """
-        pass
+    ) -> ModelResponse:
+        """Execute a model call with optional tool support."""
+        raise NotImplementedError
 
     def supports_tools(self, model: str) -> bool:
         """Check if a model supports native tool use"""
         return False
+

--- a/src/modelAccessors/gemini_accessor.py
+++ b/src/modelAccessors/gemini_accessor.py
@@ -1,10 +1,12 @@
 from os import environ
 import json
 from typing import Any, Dict, Optional
-from pydantic import TypeAdapter
+
 import google.generativeai as genai
+from pydantic import TypeAdapter
+
 from .base_accessor import BaseModelAccessor, Tool
-from dataModel.model_response import ModelResponse
+from src.dataModel.model_response import ModelResponse
 
 class GeminiAccessor(BaseModelAccessor):
     def __init__(self):
@@ -12,60 +14,35 @@ class GeminiAccessor(BaseModelAccessor):
         # Models that support function calling
         self.tool_supported_models = ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-pro"]
         
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
-        """Basic text prompting for Gemini models"""
-        model_instance = genai.GenerativeModel(model)
-        
-        # Combine system and user prompts
-        full_prompt = f"System: {system_prompt}\n\nUser: {user_prompt}"
-        
-        response = model_instance.generate_content(full_prompt)
-        
-        content = response.text
-        if not content:
-            raise ValueError("No content in response")
-            
-        # Convert content to JSON format if needed
-        try:
-            json_content = json.loads(content)
-        except json.JSONDecodeError:
-            # If the model didn't return JSON, wrap it in a simple structure
-            json_content = {"text": content}
-            
-        return TypeAdapter(ModelResponse).validate_python(json_content)
-        
-    def execute_task_with_tools(
+    def call_model(
         self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ModelResponse],
+        schema: dict,
+        model: str = "gemini-1.5-pro",
+        system_prompt: str = "",
         tools: Optional[list[Tool]] = None,
     ) -> ModelResponse:
-        """Execute task with tools - native function calling if supported"""
-        if not tools or not self.supports_tools(model):
-            return self.prompt_model(model, system_prompt, user_prompt)
-            
         model_instance = genai.GenerativeModel(model)
-        gemini_tools = self._convert_to_gemini_tools(tools)
-        
-        full_prompt = f"System: {system_prompt}\n\nUser: {user_prompt}"
-        
-        response = model_instance.generate_content(
-            full_prompt,
-            tools=gemini_tools
-        )
-        
+        full_prompt = f"System: {system_prompt}\n\nUser: {prompt}"
+
+        if tools and self.supports_tools(model):
+            gemini_tools = self._convert_to_gemini_tools(tools)
+            response = model_instance.generate_content(full_prompt, tools=gemini_tools)
+        else:
+            response = model_instance.generate_content(full_prompt)
+
         content = response.text
         if not content:
             raise ValueError("No content in response")
-            
-        # Process and convert to ModelResponse
+
         try:
             json_content = json.loads(content)
         except json.JSONDecodeError:
             json_content = {"text": content}
-            
-        return TypeAdapter(ModelResponse).validate_python(json_content)
+
+        return adapter.validate_python(json_content)
     
     def supports_tools(self, model: str) -> bool:
         """Check if model supports function calling"""

--- a/src/modelAccessors/mock_accessor.py
+++ b/src/modelAccessors/mock_accessor.py
@@ -1,11 +1,10 @@
-from .base_accessor import BaseModelAccessor, Tool
 from typing import Optional
-from src.dataModel.model_response import (
-    ModelResponse,
-    DecomposedResponse,
-    ImplementedResponse,
-)
-from src.dataModel.task import Task, TaskType
+
+from pydantic import TypeAdapter
+
+from .base_accessor import BaseModelAccessor, Tool
+from src.dataModel.task import TaskType
+from src.dataModel.model_response import ModelResponse
 
 class MockAccessor(BaseModelAccessor):
     """Mock accessor for testing without API calls"""
@@ -14,46 +13,60 @@ class MockAccessor(BaseModelAccessor):
         # Mock models that "support" tools
         self.tool_supported_models = ["mock-gpt-4", "mock-claude"]
 
-    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - simple wrapper
-        """Simpler call method used by node tests."""
-        return self.prompt_model("mock-gpt-4", "", prompt)
-    
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
-        # Return a mock decomposition for DECOMPOSE tasks
-        if "decompose" in user_prompt.lower() or "complex" in user_prompt.lower():
-            return DecomposedResponse(
-                subtasks=[
-                    Task(
-                        id="mock-1",
-                        type=TaskType.IMPLEMENT,
-                        description="Create authentication system",
-                    ),
-                    Task(
-                        id="mock-2",
-                        type=TaskType.IMPLEMENT,
-                        description="Create dashboard interface",
-                    ),
-                ],
-            )
-        else:
-            return ImplementedResponse(content="Mock implementation completed")
-    
-    def execute_task_with_tools(
+    def call_model(
         self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ModelResponse],
+        schema: dict,
+        model: str = "mock-gpt-4",
+        system_prompt: str = "",
         tools: Optional[list[Tool]] = None,
-    ) -> ModelResponse:
-        if tools and self.supports_tools(model):
-            # Simulate using tools
-            tool_names = [tool.name for tool in tools]
-            return ImplementedResponse(
-                content=f"Mock task completed using tools: {', '.join(tool_names)}"
-            )
-        else:
-            return ImplementedResponse(content="Mock task with tools completed")
+    ) -> ModelResponse:  # pragma: no cover - simple wrapper
+        data = self._build_response(prompt)
+        if data["type"] == "implemented":
+            if tools and self.supports_tools(model):
+                tool_names = ", ".join(tool.name for tool in tools)
+                data["content"] = f"Mock task completed using tools: {tool_names}"
+            elif tools:
+                data["content"] = "Mock task with tools completed"
+        return adapter.validate_python(data)
     
     def supports_tools(self, model: str) -> bool:
         """Mock tool support for certain models"""
         return model in self.tool_supported_models
+
+    def _build_response(self, prompt: str) -> dict:
+        if "mock_decompose" in prompt:
+            return {
+                "type": "decomposed",
+                "subtasks": [
+                    {
+                        "id": "mock-1",
+                        "type": TaskType.IMPLEMENT,
+                        "description": "Create authentication system",
+                    },
+                    {
+                        "id": "mock-2",
+                        "type": TaskType.IMPLEMENT,
+                        "description": "Create dashboard interface",
+                    },
+                ],
+            }
+        if "mock_follow_up" in prompt:
+            return {
+                "type": "follow_up_required",
+                "content": "Mock follow-up required",
+                "follow_up_ask": {
+                    "id": "mock-follow-up",
+                    "type": TaskType.RESEARCH,
+                    "description": "Provide additional details",
+                },
+            }
+        if "mock_fail" in prompt:
+            return {
+                "type": "failed",
+                "error_message": "Mock failure",
+                "retryable": False,
+            }
+        return {"type": "implemented", "content": "Mock implementation completed", "artifacts": []}

--- a/src/modelAccessors/openai_accessor.py
+++ b/src/modelAccessors/openai_accessor.py
@@ -1,7 +1,9 @@
 from os import environ
-from typing import Optional
+from typing import Any, Optional
+
 from openai import OpenAI
 from pydantic import TypeAdapter
+
 from .base_accessor import BaseModelAccessor, Tool
 from src.dataModel.model_response import ModelResponse
 
@@ -11,68 +13,41 @@ class OpenAIAccessor(BaseModelAccessor):
         # Models that support function calling/tools
         self.tool_supported_models = ["gpt-4", "gpt-4-turbo", "gpt-4o", "gpt-3.5-turbo-0125", "gpt-3.5-turbo"]
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str) -> ModelResponse:
-        """
-        Sends a prompt to the specified OpenAI model and returns the response.
-        """
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"}
-        )
-        
-        content: str | None = response.choices[0].message.content
-        if not content:
-            raise ValueError("No content in response")
-            
-        return TypeAdapter(ModelResponse).validate_json(content) # type: ignore
-
-    def call_model(self, prompt: str, schema) -> ModelResponse:  # pragma: no cover - thin wrapper
-        """Convenience wrapper used by simple agent nodes."""
-        return self.prompt_model("gpt-4", "", prompt)
-
-    def execute_task_with_tools(
+    def call_model(
         self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ModelResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
         tools: Optional[list[Tool]] = None,
     ) -> ModelResponse:
-        """
-        Execute task with tools - using native function calling if supported
-        """
-        if not tools or not self.supports_tools(model):
-            return self.prompt_model(model, system_prompt, user_prompt)
-        
-        # Use native OpenAI function calling
-        openai_tools = self._convert_to_openai_tools(tools)
-        
-        response = self.client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            tools=openai_tools,
-            response_format={"type": "json_object"}
-        )
-        
-        content = response.choices[0].message.content
-        if not content:
-            raise ValueError("No content in response")
-            
-        return TypeAdapter(ModelResponse).validate_json(content)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "response", "schema": schema, "strict": True},
+            },
+        }
+        if tools and self.supports_tools(model):
+            kwargs["tools"] = self._convert_to_openai_tools(tools)
+        response = self.client.chat.completions.create(**kwargs)
+        raw = response.choices[0].message.content[0].text
+        return adapter.validate_json(raw)
     
     def supports_tools(self, model: str) -> bool:
         """Check if model supports native tools/function calling"""
         return model in self.tool_supported_models
         
-    def _convert_to_openai_tools(self, tools: list[Tool]) -> list[dict[str, object]]:
+    def _convert_to_openai_tools(self, tools: list[Tool]) -> list[dict[str, Any]]:
         """Convert our Tool objects to OpenAI's tool format"""
-        openai_tools: list[dict[str, object]] = []
+        openai_tools: list[dict[str, Any]] = []
         for tool in tools:
             openai_tools.append({
                 "type": "function",

--- a/src/modelAccessors/openai_accessor.py
+++ b/src/modelAccessors/openai_accessor.py
@@ -38,7 +38,11 @@ class OpenAIAccessor(BaseModelAccessor):
         if tools and self.supports_tools(model):
             kwargs["tools"] = self._convert_to_openai_tools(tools)
         response = self.client.chat.completions.create(**kwargs)
-        raw = response.choices[0].message.content[0].text
+        message = response.choices[0].message
+        parsed = getattr(message, "parsed", None)
+        if parsed is not None:
+            return adapter.validate_python(parsed)
+        raw = message.content
         return adapter.validate_json(raw)
     
     def supports_tools(self, model: str) -> bool:

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from src.logging_utils import init_logger
 
@@ -208,10 +208,10 @@ class AgentOrchestrator:
             project.taskResults[current_task.id] = response
             project.latestResponse = response
 
-            match response.response_type:
+            match response.type:
                 case ModelResponseType.DECOMPOSED:
-                    assert isinstance(response, DecomposedResponse)
-                    new_tasks = self._enqueue_subtasks(current_task, response.subtasks)
+                    decomposed = cast(DecomposedResponse, response)
+                    new_tasks = self._enqueue_subtasks(current_task, decomposed.subtasks)
                     project.queuedTasks.extend(new_tasks)
                     current_task.status = TaskStatus.COMPLETED
                     project.inProgressTasks.remove(current_task)
@@ -219,10 +219,10 @@ class AgentOrchestrator:
                     self.logger.info(
                         "%s task completed: produced %d subtasks",
                         current_task.type.name,
-                        len(response.subtasks),
+                        len(decomposed.subtasks),
                     )
                 case ModelResponseType.IMPLEMENTED:
-                    assert isinstance(response, ImplementedResponse)
+                    implemented = cast(ImplementedResponse, response)
                     if current_task.type is TaskType.REQUIREMENTS:
                         hld = Task(
                             id=f"{current_task.id}-hld",
@@ -240,12 +240,12 @@ class AgentOrchestrator:
                     self.logger.info(
                         "%s task completed: artifacts %s",
                         current_task.type.name,
-                        ", ".join(response.artifacts) if response.artifacts else "none",
+                        ", ".join(implemented.artifacts) if implemented.artifacts else "none",
                     )
                 case ModelResponseType.FOLLOW_UP_REQUIRED:
-                    assert isinstance(response, FollowUpResponse)
+                    follow_up = cast(FollowUpResponse, response)
                     if current_task.type is TaskType.REQUIREMENTS:
-                        question = response.follow_up_ask.description
+                        question = follow_up.follow_up_ask.description
                         answer = input(question + " ")
                         desc = f"{current_task.description}\n{answer}".strip()
                         hld = Task(
@@ -267,11 +267,11 @@ class AgentOrchestrator:
                         project.failedTasks.append(current_task)
                     self.logger.info("%s task requires follow up", current_task.type.name)
                 case ModelResponseType.FAILED:
-                    assert isinstance(response, FailedResponse)
+                    failure = cast(FailedResponse, response)
                     current_task.status = TaskStatus.FAILED
                     project.inProgressTasks.remove(current_task)
                     project.failedTasks.append(current_task)
-                    self.logger.error("Task %s failed: %s", current_task.id, response.error_message)
+                    self.logger.error("Task %s failed: %s", current_task.id, failure.error_message)
 
             save_project_state(project, checkpoint_dir)
 

--- a/tests/agentNodes/test_clarifier.py
+++ b/tests/agentNodes/test_clarifier.py
@@ -1,20 +1,26 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.clarifier import Clarifier
 from src.modelAccessors.base_accessor import BaseModelAccessor
 from src.dataModel.task import Task, TaskType
 from src.dataModel.model_response import (
     FollowUpResponse,
     ImplementedResponse,
+    ClarifierResponse,
 )
 
 
 class _StubAccessor(BaseModelAccessor):
-    def call_model(self, prompt: str, schema):
-        raise NotImplementedError()
-
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ClarifierResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> ClarifierResponse:
         raise NotImplementedError()
 
 
@@ -25,7 +31,7 @@ def test_needs_followup(monkeypatch):
     monkeypatch.setattr(
         node.llm_accessor,
         "call_model",
-        lambda prompt, schema: FollowUpResponse(follow_up_ask=follow_up),
+        lambda prompt, *, adapter, schema, **kwargs: FollowUpResponse(follow_up_ask=follow_up),
     )
     task = Task(id="t1", description="Build app?", type=TaskType.REQUIREMENTS)
 
@@ -41,7 +47,7 @@ def test_no_followup(monkeypatch):
     monkeypatch.setattr(
         node.llm_accessor,
         "call_model",
-        lambda prompt, schema: ImplementedResponse(content="Requirements are clear"),
+        lambda prompt, *, adapter, schema, **kwargs: ImplementedResponse(content="Requirements are clear"),
     )
     task = Task(id="t2", description="All good", type=TaskType.REQUIREMENTS)
 

--- a/tests/agentNodes/test_clarifier.py
+++ b/tests/agentNodes/test_clarifier.py
@@ -6,7 +6,7 @@ from src.dataModel.task import Task, TaskType
 from src.dataModel.model_response import (
     FollowUpResponse,
     ImplementedResponse,
-    ClarifierResponse,
+    ModelResponse,
 )
 
 
@@ -15,12 +15,12 @@ class _StubAccessor(BaseModelAccessor):
         self,
         prompt: str,
         *,
-        adapter: TypeAdapter[ClarifierResponse],
+        adapter: TypeAdapter[ModelResponse],
         schema: dict,
         model: str = "gpt-4",
         system_prompt: str = "",
         tools=None,
-    ) -> ClarifierResponse:
+    ) -> ModelResponse:
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_deployer.py
+++ b/tests/agentNodes/test_deployer.py
@@ -1,5 +1,3 @@
-from pydantic import TypeAdapter
-
 from src.agentNodes.deployer import Deployer
 from src.dataModel.model_response import ImplementedResponse
 
@@ -8,7 +6,7 @@ def test_deployer_deploys():
     node = Deployer()
     last = ImplementedResponse(content="pytest passed", artifacts=["foo.py"])
     res = node({"last_response": last}, {})
-    parsed = TypeAdapter(Deployer.SCHEMA).validate_python(res)
+    parsed = Deployer.ADAPTER.validate_python(res)
     assert isinstance(parsed, ImplementedResponse)
     assert parsed.content == "deployed"
     assert parsed.artifacts == ["foo.py"]

--- a/tests/agentNodes/test_hld_designer.py
+++ b/tests/agentNodes/test_hld_designer.py
@@ -1,8 +1,11 @@
 from agentNodes.hld_designer import HLDDesigner
+from pydantic import TypeAdapter
+
 from dataModel.task import Task, TaskType
 from dataModel.model_response import (
     DecomposedResponse,
     ImplementedResponse,
+    DesignerResponse,
 )
 from modelAccessors.base_accessor import BaseModelAccessor
 
@@ -11,14 +14,17 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result):
         self._result = result
 
-    def call_model(self, prompt: str, schema):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[DesignerResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> DesignerResponse:
         return self._result
-
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
-        raise NotImplementedError()
 
 
 def test_decomposes_when_complex():

--- a/tests/agentNodes/test_implementer.py
+++ b/tests/agentNodes/test_implementer.py
@@ -1,3 +1,5 @@
+from pydantic import TypeAdapter
+
 from agentNodes.implementer import Implementer
 from modelAccessors.base_accessor import BaseModelAccessor
 from dataModel.model_response import ImplementedResponse
@@ -8,14 +10,17 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result: ImplementedResponse) -> None:
         self._result = result
 
-    def call_model(self, prompt: str, schema):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ImplementedResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> ImplementedResponse:
         return self._result
-
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
-        raise NotImplementedError()
 
 
 def test_implementer_returns_code():

--- a/tests/agentNodes/test_jury.py
+++ b/tests/agentNodes/test_jury.py
@@ -1,7 +1,7 @@
 from pydantic import TypeAdapter
 
 from src.agentNodes.jury import Jury
-from src.dataModel.model_response import ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse, ModelResponse
 from src.dataModel.task import Task, TaskType
 from src.modelAccessors.base_accessor import BaseModelAccessor
 
@@ -11,12 +11,12 @@ class _StubAccessor(BaseModelAccessor):
         self,
         prompt: str,
         *,
-        adapter: TypeAdapter[ImplementedResponse],
+        adapter: TypeAdapter[ModelResponse],
         schema: dict,
         model: str = "gpt-4",
         system_prompt: str = "",
         tools=None,
-    ) -> ImplementedResponse:  # pragma: no cover - unused
+    ) -> ModelResponse:  # pragma: no cover - unused
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_jury.py
+++ b/tests/agentNodes/test_jury.py
@@ -1,3 +1,5 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.jury import Jury
 from src.dataModel.model_response import ImplementedResponse
 from src.dataModel.task import Task, TaskType
@@ -5,15 +7,16 @@ from src.modelAccessors.base_accessor import BaseModelAccessor
 
 
 class _StubAccessor(BaseModelAccessor):
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
-        raise NotImplementedError()
-
-    def call_model(self, prompt: str, schema):  # pragma: no cover - unused
-        raise NotImplementedError()
-
-    def execute_task_with_tools(
-        self, model: str, system_prompt: str, user_prompt: str, tools=None
-    ):  # pragma: no cover - unused
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ImplementedResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> ImplementedResponse:  # pragma: no cover - unused
         raise NotImplementedError()
 
 

--- a/tests/agentNodes/test_lld_designer.py
+++ b/tests/agentNodes/test_lld_designer.py
@@ -11,14 +11,17 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result: ImplementedResponse | None = None):
         self._result = result or ImplementedResponse(content="x" * 25)
 
-    def call_model(self, prompt: str, schema):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ImplementedResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> ImplementedResponse:
         return self._result
-
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
-        raise NotImplementedError()
 
 
 def test_lld_returns_content():
@@ -34,8 +37,12 @@ def test_lld_returns_content():
 def test_schema_enforced(monkeypatch):
     accessor = _StubAccessor()
     node = LLDDesigner(accessor)
-    monkeypatch.setattr(node.llm_accessor, "call_model", lambda prompt, schema: object())
+    monkeypatch.setattr(
+        node.llm_accessor,
+        "call_model",
+        lambda prompt, *, adapter, schema, **kwargs: object(),
+    )
     task = Task(id="l2", description="Bad", type=TaskType.LLD)
 
     with pytest.raises(ValidationError):
-        TypeAdapter(LLDDesigner.SCHEMA).validate_python(node.execute_task(task))
+        LLDDesigner.ADAPTER.validate_python(node.execute_task(task))

--- a/tests/agentNodes/test_researcher.py
+++ b/tests/agentNodes/test_researcher.py
@@ -12,13 +12,16 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result):
         self._result = result
 
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):
-        raise NotImplementedError()
-
-    def call_model(self, prompt: str, schema):  # pragma: no cover - unused
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[ImplementedResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> ImplementedResponse:
         return self._result
 
 
@@ -46,5 +49,5 @@ def test_researcher_schema_validation():
     task = Task(id="r1", description="search", type=TaskType.RESEARCH)
 
     with pytest.raises(ValidationError):
-        TypeAdapter(Researcher.SCHEMA).validate_python(node.execute_task(task))
+        Researcher.ADAPTER.validate_python(node.execute_task(task))
 

--- a/tests/agentNodes/test_reviewer.py
+++ b/tests/agentNodes/test_reviewer.py
@@ -1,5 +1,3 @@
-from pydantic import TypeAdapter
-
 from src.agentNodes.reviewer import Reviewer
 from src.dataModel.model_response import (
     ImplementedResponse,
@@ -11,7 +9,7 @@ def test_reviewer_approves():
     node = Reviewer()
     last = ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
     res = node({"last_response": last}, {})
-    parsed = TypeAdapter(Reviewer.SCHEMA).validate_python(res)
+    parsed = Reviewer.ADAPTER.validate_python(res)
     assert isinstance(parsed, ImplementedResponse)
     assert parsed.content == "LGTM"
     assert parsed.artifacts == ["foo.py"]
@@ -21,6 +19,6 @@ def test_reviewer_rejects():
     node = Reviewer()
     last = ImplementedResponse(content="print(1)", artifacts=["foo.py"])
     res = node({"last_response": last}, {})
-    parsed = TypeAdapter(Reviewer.SCHEMA).validate_python(res)
+    parsed = Reviewer.ADAPTER.validate_python(res)
     assert isinstance(parsed, FailedResponse)
     assert parsed.error_message == "Style error"

--- a/tests/agentNodes/test_tester.py
+++ b/tests/agentNodes/test_tester.py
@@ -1,6 +1,8 @@
+from pydantic import TypeAdapter
+
 from src.agentNodes.tester import Tester
 from src.modelAccessors.base_accessor import BaseModelAccessor
-from src.dataModel.model_response import ImplementedResponse
+from src.dataModel.model_response import ImplementedResponse, TesterResponse
 from src.dataModel.task import Task, TaskType
 
 
@@ -8,14 +10,17 @@ class _StubAccessor(BaseModelAccessor):
     def __init__(self, result: ImplementedResponse) -> None:
         self._result = result
 
-    def call_model(self, prompt: str, schema):
+    def call_model(
+        self,
+        prompt: str,
+        *,
+        adapter: TypeAdapter[TesterResponse],
+        schema: dict,
+        model: str = "gpt-4",
+        system_prompt: str = "",
+        tools=None,
+    ) -> TesterResponse:
         return self._result
-
-    def prompt_model(self, model: str, system_prompt: str, user_prompt: str):  # pragma: no cover - unused
-        raise NotImplementedError()
-
-    def execute_task_with_tools(self, model: str, system_prompt: str, user_prompt: str, tools=None):  # pragma: no cover - unused
-        raise NotImplementedError()
 
 
 def test_tester_passed():

--- a/tests/agentNodes/test_tester.py
+++ b/tests/agentNodes/test_tester.py
@@ -2,7 +2,10 @@ from pydantic import TypeAdapter
 
 from src.agentNodes.tester import Tester
 from src.modelAccessors.base_accessor import BaseModelAccessor
-from src.dataModel.model_response import ImplementedResponse, TesterResponse
+from src.dataModel.model_response import (
+    ImplementedResponse,
+    ModelResponse,
+)
 from src.dataModel.task import Task, TaskType
 
 
@@ -14,12 +17,12 @@ class _StubAccessor(BaseModelAccessor):
         self,
         prompt: str,
         *,
-        adapter: TypeAdapter[TesterResponse],
+        adapter: TypeAdapter[ModelResponse],
         schema: dict,
         model: str = "gpt-4",
         system_prompt: str = "",
         tools=None,
-    ) -> TesterResponse:
+    ) -> ModelResponse:
         return self._result
 
 

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -182,6 +182,7 @@ def test_resume_from_checkpoint(monkeypatch, tmp_path):
         TaskType.IMPLEMENT: lambda acc: impl_factory(),
     }
     monkeypatch.setattr(orchestrator, "NODE_FACTORY", node_map, raising=False)
+    monkeypatch.setattr(orchestrator.orchestrator, "NODE_FACTORY", node_map, raising=False)
     monkeypatch.setattr(
         orchestrator.AgentOrchestrator,
         "_get_accessor",

--- a/tests/test_mock_accessor.py
+++ b/tests/test_mock_accessor.py
@@ -1,0 +1,30 @@
+from pydantic import TypeAdapter
+
+from src.modelAccessors.mock_accessor import MockAccessor
+from src.dataModel.model_response import (
+    FollowUpResponse,
+    FailedResponse,
+    ClarifierResponse,
+)
+
+
+def test_mock_accessor_follow_up_response():
+    accessor = MockAccessor()
+    adapter = TypeAdapter(ClarifierResponse)
+    schema = adapter.json_schema()
+    response = accessor.call_model(
+        "mock_follow_up", adapter=adapter, schema=schema, model="mock-model"
+    )
+    assert isinstance(response, FollowUpResponse)
+    assert response.follow_up_ask.description
+
+
+def test_mock_accessor_failed_response():
+    accessor = MockAccessor()
+    adapter = TypeAdapter(FailedResponse)
+    schema = adapter.json_schema()
+    response = accessor.call_model(
+        "mock_fail", adapter=adapter, schema=schema, model="mock-model"
+    )
+    assert isinstance(response, FailedResponse)
+    assert response.error_message

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,7 @@ def test_model_response_round_trip_and_discriminator(cls, kwargs, tag):
     packed = orig.model_dump()
     restored = cls.model_validate(packed)
     assert restored == orig
-    assert packed["response_type"] == tag
+    assert packed["type"] == tag
 
 
 def test_task_allows_tools():

--- a/tests/test_nodes_e2e.py
+++ b/tests/test_nodes_e2e.py
@@ -14,19 +14,15 @@ from src.dataModel.model_response import (
 import json
 
 
-def _patch_accessor(accessor: MockAccessor, *, call_model=None, exec_tools=None) -> MockAccessor:
+def _patch_accessor(accessor: MockAccessor, *, call_model=None) -> MockAccessor:
     if call_model:
-        def patched_prompt(model: str, system_prompt: str, user_prompt: str):
-            return call_model(user_prompt, None)
-        accessor.prompt_model = patched_prompt  # type: ignore
-    if exec_tools:
-        def patched_exec(model: str, system_prompt: str, user_prompt: str, tools=None):
-            return exec_tools(model, system_prompt, user_prompt, tools)
-        accessor.execute_task_with_tools = patched_exec  # type: ignore
+        def patched_call(prompt: str, *, adapter, schema, **kwargs):
+            return call_model(prompt, adapter, schema, **kwargs)
+        accessor.call_model = patched_call  # type: ignore
     return accessor
 
 
-def _hld_call_model(prompt: str, schema):
+def _hld_call_model(prompt: str, adapter, schema, **kwargs):
     subtasks = [
         Task(id="r1", description="research", type=TaskType.RESEARCH),
         Task(id="i1", description="impl", type=TaskType.IMPLEMENT),
@@ -37,15 +33,15 @@ def _hld_call_model(prompt: str, schema):
     return DecomposedResponse(subtasks=subtasks)
 
 
-def _research_exec(model: str, system_prompt: str, user_prompt: str, tools=None):
+def _research_exec(prompt: str, adapter, schema, *, tools=None, **kwargs):
     return ImplementedResponse(artifacts=["https://example.com"])
 
 
-def _impl_call_model(prompt: str, schema):
+def _impl_call_model(prompt: str, adapter, schema, **kwargs):
     return ImplementedResponse(content="def foo(): pass", artifacts=["foo.py"])
 
 
-def _test_call_model(prompt: str, schema):
+def _test_call_model(prompt: str, adapter, schema, **kwargs):
     return ImplementedResponse(content="pytest passed")
 
 
@@ -72,7 +68,7 @@ def test_end_to_end_chain(monkeypatch, tmp_path):
     monkeypatch.setitem(
         NODE_FACTORY,
         TaskType.RESEARCH,
-        lambda acc: Researcher(_patch_accessor(acc, exec_tools=_research_exec)),
+        lambda acc: Researcher(_patch_accessor(acc, call_model=_research_exec)),
     )
     monkeypatch.setitem(
         NODE_FACTORY,
@@ -155,7 +151,7 @@ def test_end_to_end_checkpoint_resume(monkeypatch, tmp_path):
     monkeypatch.setitem(
         NODE_FACTORY,
         TaskType.RESEARCH,
-        lambda acc: Researcher(_patch_accessor(acc, exec_tools=_research_exec)),
+        lambda acc: Researcher(_patch_accessor(acc, call_model=_research_exec)),
     )
     monkeypatch.setitem(
         NODE_FACTORY,


### PR DESCRIPTION
## Summary
- model responses use a discriminated `type` enum with extra keys forbidden
- consolidated accessors into a single `call_model` that accepts schema and optional tools
- OpenAI accessor submits JSON schema via `response_format` and validates with Pydantic
- orchestrator branches on `response.type` enum instead of class-based matching

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d5293c0c4832dbddf3589d0c74611